### PR TITLE
Fix Paths After Org Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can learn more about the full Deepgram API at [https://developers.deepgram.c
 # Installation
 
 ```bash
-go get github.com/deepgram-devs/deepgram-go-sdk
+go get github.com/deepgram/deepgram-go-sdk
 ```
 
 # Requirements
@@ -594,7 +594,7 @@ To make sure our community is safe for all, be sure to review and agree to our
 We love to hear from you so if you have questions, comments or find a bug in the
 project, let us know! You can either:
 
-- [Open an issue in this repository](https://github.com/deepgram-devs/deepgram-dotnet-sdk/issues/new)
+- [Open an issue in this repository](https://github.com/deepgram/deepgram-dotnet-sdk/issues/new)
 - [Join the Deepgram Github Discussions Community](https://github.com/orgs/deepgram/discussions)
 - [Join the Deepgram Discord Community](https://discord.gg/xWRaCDBtW4)
 

--- a/docs.go
+++ b/docs.go
@@ -6,8 +6,8 @@
 	This SDK provides Go library for performing Prerecorded and Live/Streaming operations
 	on the Deepgram.com Platform.
 
-	GitHub repo: https://github.com/deepgram-devs/deepgram-go-sdk
-	Go SDK Examples: https://github.com/deepgram-devs/deepgram-go-sdk/tree/main/examples
+	GitHub repo: https://github.com/deepgram/deepgram-go-sdk
+	Go SDK Examples: https://github.com/deepgram/deepgram-go-sdk/tree/main/examples
 
 	Deepgram Platform API reference: https://developers.deepgram.com/reference
 	Documentation: https://developers.deepgram.com/docs
@@ -20,6 +20,6 @@
 package sdk
 
 import (
-	_ "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/live"
-	_ "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	_ "github.com/deepgram/deepgram-go-sdk/pkg/client/live"
+	_ "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )

--- a/examples/manage/balances/main.go
+++ b/examples/manage/balances/main.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"os"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 func main() {

--- a/examples/manage/invitations/main.go
+++ b/examples/manage/invitations/main.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"os"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 func main() {

--- a/examples/manage/keys/main.go
+++ b/examples/manage/keys/main.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"os"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 func main() {

--- a/examples/manage/members/main.go
+++ b/examples/manage/members/main.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"os"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 const (

--- a/examples/manage/projects/main.go
+++ b/examples/manage/projects/main.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"os"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 func main() {

--- a/examples/manage/scopes/main.go
+++ b/examples/manage/scopes/main.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"os"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 const (

--- a/examples/manage/usage/main.go
+++ b/examples/manage/usage/main.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"os"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 func main() {

--- a/examples/prerecorded/callback/callback/main.go
+++ b/examples/prerecorded/callback/callback/main.go
@@ -13,9 +13,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	prerecorded "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/prerecorded/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	prerecorded "github.com/deepgram/deepgram-go-sdk/pkg/api/prerecorded/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 const (

--- a/examples/prerecorded/callback/endpoint/main.go
+++ b/examples/prerecorded/callback/endpoint/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/prerecorded/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/prerecorded/v1/interfaces"
 )
 
 type SampleProxy struct {

--- a/examples/prerecorded/file/main.go
+++ b/examples/prerecorded/file/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	prerecorded "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/prerecorded/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	prerecorded "github.com/deepgram/deepgram-go-sdk/pkg/api/prerecorded/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 const (

--- a/examples/prerecorded/stream/main.go
+++ b/examples/prerecorded/stream/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	prerecorded "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/prerecorded/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	prerecorded "github.com/deepgram/deepgram-go-sdk/pkg/api/prerecorded/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 const (

--- a/examples/prerecorded/url/main.go
+++ b/examples/prerecorded/url/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	prerecorded "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/prerecorded/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	prerecorded "github.com/deepgram/deepgram-go-sdk/pkg/api/prerecorded/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 const (

--- a/examples/streaming/http/main.go
+++ b/examples/streaming/http/main.go
@@ -13,8 +13,8 @@ import (
 	"os"
 	"reflect"
 
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/live"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/live"
 )
 
 const (

--- a/examples/streaming/microphone/README.md
+++ b/examples/streaming/microphone/README.md
@@ -14,7 +14,7 @@ export DEEPGRAM_API_KEY=YOUR-APP-KEY-HERE
 
 ## Installation
 
-The Live API (Real-Time) example makes use of a [microphone package](https://github.com/deepgram-devs/deepgram-go-sdk/tree/main/pkg/audio/microphone) contained within the repository. That package makes use of the [PortAudio library](http://www.portaudio.com/) which is a cross-platform open source audio library. If you are on Linux, you can install this library using whatever package manager is available (yum, apt, etc.) on your operating system. If you are on macOS, you can install this library using [brew](https://brew.sh/).
+The Live API (Real-Time) example makes use of a [microphone package](https://github.com/deepgram/deepgram-go-sdk/tree/main/pkg/audio/microphone) contained within the repository. That package makes use of the [PortAudio library](http://www.portaudio.com/) which is a cross-platform open source audio library. If you are on Linux, you can install this library using whatever package manager is available (yum, apt, etc.) on your operating system. If you are on macOS, you can install this library using [brew](https://brew.sh/).
 
 [dg-console]: https://console.deepgram.com/
 [dg-signup]: https://console.deepgram.com/signup

--- a/examples/streaming/microphone/main.go
+++ b/examples/streaming/microphone/main.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"strings"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1/interfaces"
-	microphone "github.com/deepgram-devs/deepgram-go-sdk/pkg/audio/microphone"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/live"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+	microphone "github.com/deepgram/deepgram-go-sdk/pkg/audio/microphone"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/live"
 )
 
 type MyCallback struct{}

--- a/examples/streaming/replay/main.go
+++ b/examples/streaming/replay/main.go
@@ -12,9 +12,9 @@ import (
 	"log"
 	"os"
 
-	replay "github.com/deepgram-devs/deepgram-go-sdk/pkg/audio/replay"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/live"
+	replay "github.com/deepgram/deepgram-go-sdk/pkg/audio/replay"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/live"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,30 +1,27 @@
-module github.com/deepgram-devs/deepgram-go-sdk
+module github.com/deepgram/deepgram-go-sdk
 
 go 1.18
 
 require (
-	github.com/Jeffail/gabs/v2 v2.6.1
+	github.com/dvonthenen/websocket v1.5.1-dyv.2
 	github.com/google/go-querystring v1.1.0
-	github.com/gorilla/websocket v1.5.0
+	github.com/gordonklaus/portaudio v0.0.0-20230709114228-aafa478834f5
+	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f
+	github.com/youpy/go-wav v0.3.2
+	k8s.io/klog/v2 v2.110.1
 )
 
 require (
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/jarcoal/httpmock v1.3.0 // indirect
-	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+	github.com/jarcoal/httpmock v1.3.0
 )
 
 require (
-	github.com/dvonthenen/websocket v1.5.1-dyv.2 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
-	github.com/gordonklaus/portaudio v0.0.0-20230709114228-aafa478834f5 // indirect
-	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/youpy/go-riff v0.1.0 // indirect
-	github.com/youpy/go-wav v0.3.2 // indirect
 	github.com/zaf/g711 v0.0.0-20190814101024-76a4a538f52b // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	k8s.io/klog/v2 v2.110.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,5 @@
-github.com/Jeffail/gabs/v2 v2.6.1 h1:wwbE6nTQTwIMsMxzi6XFQQYRZ6wDc1mSdxoAN+9U4Gk=
-github.com/Jeffail/gabs/v2 v2.6.1/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
-github.com/Jeffail/gabs/v2 v2.7.0 h1:Y2edYaTcE8ZpRsR2AtmPu5xQdFDIthFG0jYhu5PY8kg=
-github.com/Jeffail/gabs/v2 v2.7.0/go.mod h1:dp5ocw1FvBBQYssgHsG7I1WYsiLRtkUaB1FEtSwvNUw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/dvonthenen/websocket v1.5.1-dyv.2 h1:OXlWJJkeHt8k4+MEI0Y8SQjY2ihHYD2z/tI7sZZfsnA=
 github.com/dvonthenen/websocket v1.5.1-dyv.2/go.mod h1:q2GbopbpFJvBP4iqVvqwwahVmvu2HnCfdqCWDoQVKMM=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
@@ -17,8 +14,6 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gordonklaus/portaudio v0.0.0-20230709114228-aafa478834f5 h1:5AlozfqaVjGYGhms2OsdUyfdJME76E6rx5MdGpjzZpc=
 github.com/gordonklaus/portaudio v0.0.0-20230709114228-aafa478834f5/go.mod h1:WY8R6YKlI2ZI3UyzFk7P6yGSuS+hFwNtEzrexRyD7Es=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
@@ -28,9 +23,13 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/youpy/go-riff v0.1.0 h1:vZO/37nI4tIET8tQI0Qn0Y79qQh99aEpponTPiPut7k=
 github.com/youpy/go-riff v0.1.0/go.mod h1:83nxdDV4Z9RzrTut9losK7ve4hUnxUR8ASSz4BsKXwQ=
@@ -42,10 +41,10 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
 k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=

--- a/pkg/api/live/v1/default.go
+++ b/pkg/api/live/v1/default.go
@@ -13,7 +13,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/live/v1/interfaces"
 )
 
 type DefaultCallbackHandler struct {

--- a/pkg/api/live/v1/router.go
+++ b/pkg/api/live/v1/router.go
@@ -11,7 +11,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/live/v1/interfaces"
 )
 
 // MessageRouter is helper struct that routes events

--- a/pkg/api/manage/v1/balances.go
+++ b/pkg/api/manage/v1/balances.go
@@ -17,9 +17,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/version"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 // ListBalances lists all balances for a project

--- a/pkg/api/manage/v1/invitations.go
+++ b/pkg/api/manage/v1/invitations.go
@@ -21,9 +21,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/version"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 // ListInvitations lists all invitations for a project

--- a/pkg/api/manage/v1/keys.go
+++ b/pkg/api/manage/v1/keys.go
@@ -22,9 +22,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/version"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 // ListKeys lists all keys for a project

--- a/pkg/api/manage/v1/manage.go
+++ b/pkg/api/manage/v1/manage.go
@@ -5,7 +5,7 @@
 package manage
 
 import (
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 // ManageClient is the client for the Deepgram Manage API

--- a/pkg/api/manage/v1/members.go
+++ b/pkg/api/manage/v1/members.go
@@ -17,9 +17,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/version"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 // ListMembers lists all members for a project

--- a/pkg/api/manage/v1/projects.go
+++ b/pkg/api/manage/v1/projects.go
@@ -21,9 +21,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/version"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 // ListProjects lists all projects for a user

--- a/pkg/api/manage/v1/scopes.go
+++ b/pkg/api/manage/v1/scopes.go
@@ -19,9 +19,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/version"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 // GetMemberScopes gets the scopes for a member

--- a/pkg/api/manage/v1/usage.go
+++ b/pkg/api/manage/v1/usage.go
@@ -19,9 +19,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/version"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 // ListRequests lists all requests for a project

--- a/pkg/api/prerecorded/v1/prerecorded.go
+++ b/pkg/api/prerecorded/v1/prerecorded.go
@@ -11,9 +11,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/prerecorded/v1/interfaces"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	api "github.com/deepgram/deepgram-go-sdk/pkg/api/prerecorded/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 type PrerecordedClient struct {

--- a/pkg/api/version/live-version.go
+++ b/pkg/api/version/live-version.go
@@ -14,8 +14,8 @@ import (
 	"github.com/google/go-querystring/query"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	common "github.com/deepgram-devs/deepgram-go-sdk/pkg/common"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
 )
 
 const (

--- a/pkg/api/version/manage-version.go
+++ b/pkg/api/version/manage-version.go
@@ -15,8 +15,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	common "github.com/deepgram-devs/deepgram-go-sdk/pkg/common"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
 	"github.com/google/go-querystring/query"
 )
 

--- a/pkg/api/version/prerecorded-version.go
+++ b/pkg/api/version/prerecorded-version.go
@@ -14,8 +14,8 @@ import (
 	"github.com/google/go-querystring/query"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	common "github.com/deepgram-devs/deepgram-go-sdk/pkg/common"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
 )
 
 const (

--- a/pkg/client/live/client.go
+++ b/pkg/client/live/client.go
@@ -21,10 +21,10 @@ import (
 	"github.com/dvonthenen/websocket"
 	klog "k8s.io/klog/v2"
 
-	live "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1"
-	msginterfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1/interfaces"
-	version "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/version"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	live "github.com/deepgram/deepgram-go-sdk/pkg/api/live/v1"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 /*

--- a/pkg/client/live/init.go
+++ b/pkg/client/live/init.go
@@ -8,7 +8,7 @@ This package contains the initialization code for the Deepgram Go SDK
 package live
 
 import (
-	common "github.com/deepgram-devs/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
 )
 
 const (

--- a/pkg/client/live/types.go
+++ b/pkg/client/live/types.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/dvonthenen/websocket"
 
-	live "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1"
-	msginterface "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1/interfaces"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	live "github.com/deepgram/deepgram-go-sdk/pkg/api/live/v1"
+	msginterface "github.com/deepgram/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 // ClientOptions defines any options for the client

--- a/pkg/client/prerecorded/client.go
+++ b/pkg/client/prerecorded/client.go
@@ -17,9 +17,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	version "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/version"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	rest "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/rest"
+	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	rest "github.com/deepgram/deepgram-go-sdk/pkg/client/rest"
 )
 
 type urlSource struct {

--- a/pkg/client/prerecorded/init.go
+++ b/pkg/client/prerecorded/init.go
@@ -8,7 +8,7 @@ This package contains the initialization code for the Deepgram Go SDK
 package prerecorded
 
 import (
-	common "github.com/deepgram-devs/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
 )
 
 const (

--- a/pkg/client/prerecorded/types.go
+++ b/pkg/client/prerecorded/types.go
@@ -5,7 +5,7 @@
 package prerecorded
 
 import (
-	rest "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/rest"
+	rest "github.com/deepgram/deepgram-go-sdk/pkg/client/rest"
 )
 
 // ClientOptions defines any options for the client

--- a/pkg/client/rest/debug.go
+++ b/pkg/client/rest/debug.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/deepgram-devs/deepgram-go-sdk/pkg/client/rest/debug"
+	"github.com/deepgram/deepgram-go-sdk/pkg/client/rest/debug"
 )
 
 var (

--- a/pkg/client/rest/http.go
+++ b/pkg/client/rest/http.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 )
 
 // New allocated a Simple HTTP client

--- a/pkg/client/rest/init.go
+++ b/pkg/client/rest/init.go
@@ -8,7 +8,7 @@ This package contains the initialization code for the Deepgram Go SDK
 package rest
 
 import (
-	common "github.com/deepgram-devs/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
 )
 
 const (

--- a/pkg/client/rest/rest.go
+++ b/pkg/client/rest/rest.go
@@ -15,8 +15,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	common "github.com/deepgram-devs/deepgram-go-sdk/pkg/common"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
 )
 
 func NewWithDefaults() *Client {

--- a/tests/prerecorded_test.go
+++ b/tests/prerecorded_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/jarcoal/httpmock"
 
-	prerecorded "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/prerecorded/v1"
-	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/prerecorded"
+	prerecorded "github.com/deepgram/deepgram-go-sdk/pkg/api/prerecorded/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
 
 func TestPrerecordedFromURL(t *testing.T) {


### PR DESCRIPTION
## Proposed changes

This fixes all paths from `github.com/deepgram-devs` to `github.com/deepgram` after transferring the repo to the `deepgram` org.

The old GH URL https://github.com/deepgram-devs/deepgram-go-sdk will continue to redirect all traffic to the new org URL https://github.com/deepgram/deepgram-go-sdk

Verified `examples` work!

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
