### PR TITLE
Fix More Go Lint Issues With Struct Names

### DIFF
--- a/examples/prerecorded/url/main.go
+++ b/examples/prerecorded/url/main.go
@@ -28,22 +28,21 @@ func main() {
 	// context
 	ctx := context.Background()
 
+	// options
+	options := interfaces.PreRecordedTranscriptionOptions{
+		Punctuate:  true,
+		Diarize:    true,
+		Language:   "en-US",
+		Utterances: true,
+		Redact:     []string{"pci", "ssn"},
+	}
+
 	//client
 	c := client.NewWithDefaults()
 	dg := prerecorded.New(c)
 
 	// send stream
-	res, err := dg.FromURL(
-		ctx,
-		url,
-		interfaces.PreRecordedTranscriptionOptions{
-			Punctuate:  true,
-			Diarize:    true,
-			Language:   "en-US",
-			Utterances: true,
-			Redact:     []string{"pci", "ssn"},
-		},
-	)
+	res, err := dg.FromURL(ctx, url, options)
 	if err != nil {
 		log.Printf("FromURL failed. Err: %v\n", err)
 		os.Exit(1)

--- a/examples/streaming/microphone/main.go
+++ b/examples/streaming/microphone/main.go
@@ -54,18 +54,18 @@ func main() {
 	ctx := context.Background()
 
 	// options
-	transcriptOptions := interfaces.LiveTranscriptionOptions{
-		Language:    "en-US",
-		Punctuate:   true,
-		Encoding:    "linear16",
-		Channels:    1,
-		Sample_rate: 16000,
+	options := interfaces.LiveTranscriptionOptions{
+		Language:   "en-US",
+		Punctuate:  true,
+		Encoding:   "linear16",
+		Channels:   1,
+		SampleRate: 16000,
 	}
 
 	// callback
 	callback := MyCallback{}
 
-	dgClient, err := client.NewWithDefaults(ctx, transcriptOptions, callback)
+	dgClient, err := client.NewWithDefaults(ctx, options, callback)
 	if err != nil {
 		log.Println("ERROR creating LiveTranscription connection:", err)
 		return

--- a/examples/streaming/replay/main.go
+++ b/examples/streaming/replay/main.go
@@ -28,15 +28,15 @@ func main() {
 	ctx := context.Background()
 
 	// options
-	transcriptOptions := interfaces.LiveTranscriptionOptions{
-		Language:    "en-US",
-		Punctuate:   true,
-		Encoding:    "mulaw",
-		Channels:    1,
-		Sample_rate: 8000,
+	options := interfaces.LiveTranscriptionOptions{
+		Language:   "en-US",
+		Punctuate:  true,
+		Encoding:   "mulaw",
+		Channels:   1,
+		SampleRate: 8000,
 	}
 
-	dgClient, err := client.NewForDemo(ctx, transcriptOptions)
+	dgClient, err := client.NewForDemo(ctx, options)
 	if err != nil {
 		log.Println("ERROR creating LiveTranscription connection:", err)
 		return

--- a/pkg/client/interfaces/types-prerecorded.go
+++ b/pkg/client/interfaces/types-prerecorded.go
@@ -14,33 +14,34 @@ from the Deepgram API
 Please see the documentation for live/streaming for more details:
 https://developers.deepgram.com/reference/pre-recorded
 */
+
 type PreRecordedTranscriptionOptions struct {
-	Alternatives       int         `json:"alternatives" url:"alternatives,omitempty" `
-	Callback           string      `json:"callback" url:"callback,omitempty" `
-	DetectEntities     bool        `json:"detect_entities" url:"detect_entities,omitempty"`
-	DetectLanguage     bool        `json:"detect_language" url:"detect_language,omitempty" `
-	DetectTopics       bool        `json:"detect_topics" url:"detect_topics,omitempty" `
-	Diarize            bool        `json:"diarize" url:"diarize,omitempty" `
-	Diarize_version    string      `json:"diarize_version" url:"diarize_version,omitempty" `
-	Keywords           []string    `json:"keywords" url:"keywords,omitempty" `
-	Language           string      `json:"language" url:"language,omitempty" `
-	Model              string      `json:"model" url:"model,omitempty" `
-	Multichannel       bool        `json:"multichannel" url:"multichannel,omitempty" `
-	Numerals           bool        `json:"numerals" url:"numerals,omitempty" ` // Same as Numbers, old name for same option
-	Paragraphs         bool        `json:"paragraphs" url:"paragraphs,omitempty" `
-	Profanity_filter   bool        `json:"profanity_filter" url:"profanity_filter,omitempty" `
-	Punctuate          bool        `json:"punctuate" url:"punctuate,omitempty" `
-	Redact             []string    `json:"redact" url:"redact,omitempty" `
-	Replace            []string    `json:"replace" url:"replace,omitempty" `
-	Search             []string    `json:"search" url:"search,omitempty" `
-	Sentiment          bool        `json:"sentiment" url:"sentiment,omitempty" `
-	SentimentThreshold float64     `json:"sentiment_threshold" url:"sentiment_threshold,omitempty" `
-	SmartFormat        bool        `json:"smart_format" url:"smart_format,omitempty" `
-	Summarize          interface{} `json:"summarize" url:"summarize,omitempty" ` // bool | string
-	Tag                []string    `json:"tag" url:"tag,omitempty"`
-	Tier               string      `json:"tier" url:"tier,omitempty" `
-	Utterances         bool        `json:"utterances" url:"utterances,omitempty" `
-	Utt_split          float64     `json:"utt_split" url:"utt_split,omitempty" `
-	Version            string      `json:"version" url:"version,omitempty" `
-	FillerWords        string      `json:"filler_words" url:"filler_words,omitempty" `
+	Alternatives       int      `json:"alternatives,omitempty" url:"alternatives,omitempty"`
+	Callback           string   `json:"callback,omitempty" url:"callback,omitempty"`
+	DetectEntities     bool     `json:"detect_entities,omitempty" url:"detect_entities,omitempty"`
+	DetectLanguage     bool     `json:"detect_language,omitempty" url:"detect_language,omitempty"`
+	DetectTopics       bool     `json:"detect_topics,omitempty" url:"detect_topics,omitempty"`
+	Diarize            bool     `json:"diarize,omitempty" url:"diarize,omitempty"`
+	DiarizeVersion     string   `json:"diarize_version,omitempty" url:"diarize_version,omitempty"`
+	FillerWords        string   `json:"filler_words,omitempty" url:"filler_words,omitempty"`
+	Keywords           []string `json:"keywords,omitempty" url:"keywords,omitempty"`
+	Language           string   `json:"language,omitempty" url:"language,omitempty"`
+	Model              string   `json:"model,omitempty" url:"model,omitempty"`
+	Multichannel       bool     `json:"multichannel,omitempty" url:"multichannel,omitempty"`
+	Numerals           bool     `json:"numerals,omitempty" url:"numerals,omitempty"`
+	Paragraphs         bool     `json:"paragraphs,omitempty" url:"paragraphs,omitempty"`
+	ProfanityFilter    bool     `json:"profanity_filter,omitempty" url:"profanity_filter,omitempty"`
+	Punctuate          bool     `json:"punctuate,omitempty" url:"punctuate,omitempty"`
+	Redact             []string `json:"redact,omitempty" url:"redact,omitempty"`
+	Replace            []string `json:"replace,omitempty" url:"replace,omitempty"`
+	Search             []string `json:"search,omitempty" url:"search,omitempty"`
+	Sentiment          bool     `json:"sentiment,omitempty" url:"sentiment,omitempty"`
+	SentimentThreshold float64  `json:"sentiment_threshold,omitempty" url:"sentiment_threshold,omitempty"`
+	SmartFormat        bool     `json:"smart_format,omitempty" url:"smart_format,omitempty"`
+	Summarize          string   `json:"summarize,omitempty" url:"summarize,omitempty"`
+	Tag                []string `json:"tag,omitempty" url:"tag,omitempty"`
+	Tier               string   `json:"tier,omitempty" url:"tier,omitempty"`
+	UttSplit           float64  `json:"utt_split,omitempty" url:"utt_split,omitempty"`
+	Utterances         bool     `json:"utterances,omitempty" url:"utterances,omitempty"`
+	Version            string   `json:"version,omitempty" url:"version,omitempty"`
 }

--- a/pkg/client/interfaces/types-stream.go
+++ b/pkg/client/interfaces/types-stream.go
@@ -15,28 +15,28 @@ Please see the documentation for live/streaming for more details:
 https://developers.deepgram.com/reference/streaming
 */
 type LiveTranscriptionOptions struct {
-	Alternatives     int      `json:"alternatives" url:"alternatives,omitempty" `
-	Callback         string   `json:"callback" url:"callback,omitempty" `
-	Channels         int      `json:"channels" url:"channels,omitempty" `
-	Diarize          bool     `json:"diarize" url:"diarize,omitempty" `
-	Diarize_version  string   `json:"diarize_version" url:"diarize_version,omitempty" `
-	Encoding         string   `json:"encoding" url:"encoding,omitempty" `
-	Endpointing      string   `json:"endpointing" url:"endpointing,omitempty" ` // Can be "false" to disable endpointing, or can be the milliseconds of silence to wait before returning a transcript. Default is 10 milliseconds. Is string here so it can accept "false" as a value.
-	Interim_results  bool     `json:"interim_results" url:"interim_results,omitempty" `
-	Keywords         []string `json:"keywords" url:"keywords,omitempty" `
-	Language         string   `json:"language" url:"language,omitempty" `
-	Model            string   `json:"model" url:"model,omitempty" `
-	Multichannel     bool     `json:"multichannel" url:"multichannel,omitempty" `
-	Numerals         bool     `json:"numerals" url:"numerals,omitempty" `
-	Profanity_filter bool     `json:"profanity_filter" url:"profanity_filter,omitempty" `
-	Punctuate        bool     `json:"punctuate" url:"punctuate,omitempty" `
-	Redact           []string `json:"redact" url:"redact,omitempty" `
-	Replace          string   `json:"replace" url:"replace,omitempty" `
-	Sample_rate      int      `json:"sample_rate" url:"sample_rate,omitempty" `
-	Search           []string `json:"search" url:"search,omitempty" `
-	Smart_format     bool     `json:"smart_format" url:"smart_format,omitempty" `
-	Tag              []string `json:"tag" url:"tag,omitempty" `
-	Tier             string   `json:"tier" url:"tier,omitempty" `
-	Version          string   `json:"version" url:"version,omitempty" `
-	FillerWords      string   `json:"filler_words" url:"filler_words,omitempty" `
+	Alternatives    int      `json:"alternatives,omitempty" url:"alternatives,omitempty"`
+	Callback        string   `json:"callback,omitempty" url:"callback,omitempty"`
+	Channels        int      `json:"channels,omitempty" url:"channels,omitempty"`
+	Diarize         bool     `json:"diarize,omitempty" url:"diarize,omitempty"`
+	DiarizeVersion  string   `json:"diarize_version,omitempty" url:"diarize_version,omitempty"`
+	Encoding        string   `json:"encoding,omitempty" url:"encoding,omitempty"`
+	Endpointing     string   `json:"endpointing,omitempty" url:"endpointing,omitempty"`
+	FillerWords     string   `json:"filler_words,omitempty" url:"filler_words,omitempty"`
+	InterimResults  bool     `json:"interim_results,omitempty" url:"interim_results,omitempty"`
+	Keywords        []string `json:"keywords,omitempty" url:"keywords,omitempty"`
+	Language        string   `json:"language,omitempty" url:"language,omitempty"`
+	Model           string   `json:"model,omitempty" url:"model,omitempty"`
+	Multichannel    bool     `json:"multichannel,omitempty" url:"multichannel,omitempty"`
+	Numerals        bool     `json:"numerals,omitempty" url:"numerals,omitempty"`
+	ProfanityFilter bool     `json:"profanity_filter,omitempty" url:"profanity_filter,omitempty"`
+	Punctuate       bool     `json:"punctuate,omitempty" url:"punctuate,omitempty"`
+	Redact          []string `json:"redact,omitempty" url:"redact,omitempty"`
+	Replace         []string `json:"replace,omitempty" url:"replace,omitempty"`
+	SampleRate      int      `json:"sample_rate,omitempty" url:"sample_rate,omitempty"`
+	Search          []string `json:"search,omitempty" url:"search,omitempty"`
+	SmartFormat     bool     `json:"smart_format,omitempty" url:"smart_format,omitempty"`
+	Tag             []string `json:"tag,omitempty" url:"tag,omitempty"`
+	Tier            string   `json:"tier,omitempty" url:"tier,omitempty"`
+	Version         string   `json:"version,omitempty" url:"version,omitempty"`
 }

--- a/tests/prerecorded_test.go
+++ b/tests/prerecorded_test.go
@@ -145,7 +145,7 @@ func TestPrerecordedFromURL(t *testing.T) {
 			context.Background(),
 			MockAudioURL,
 			interfaces.PreRecordedTranscriptionOptions{
-				Summarize: true,
+				Summarize: "true",
 			})
 
 		if err != nil {


### PR DESCRIPTION
## Proposed changes

This fixes more linting issues with struct variable names. This will throw errors on strict linting with Go.

Verified that all prerecord and live examples still work correctly.

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

NA
