### PR TITLE
Updates for Go Lint Using golangci-lint

### DIFF
--- a/pkg/api/live/v1/default.go
+++ b/pkg/api/live/v1/default.go
@@ -18,9 +18,7 @@ import (
 
 // DefaultCallbackHandler is a default callback handler for live transcription
 // Simply prints the transcript to stdout
-type DefaultCallbackHandler struct {
-	sb strings.Builder
-}
+type DefaultCallbackHandler struct{}
 
 // NewDefaultCallbackHandler creates a new DefaultCallbackHandler
 func NewDefaultCallbackHandler() DefaultCallbackHandler {

--- a/pkg/audio/microphone/microphone.go
+++ b/pkg/audio/microphone/microphone.go
@@ -17,12 +17,18 @@ import (
 
 // Initialize inits the library
 func Initialize() {
-	portaudio.Initialize()
+	err := portaudio.Initialize()
+	if err != nil {
+		klog.V(1).Printf("portaudio.Initialize failed. Err: %v\n", err)
+	}
 }
 
 // Teardown cleans up the library
 func Teardown() {
-	portaudio.Terminate()
+	err := portaudio.Terminate()
+	if err != nil {
+		klog.V(1).Printf("portaudio.Terminate failed. Err: %v\n", err)
+	}
 }
 
 // New creates a new microphone using portaudio
@@ -99,8 +105,6 @@ func (m *Microphone) Stream(w io.Writer) error {
 			klog.V(7).Infof("io.Writer succeeded. Bytes written: %d\n", byteCount)
 		}
 	}
-
-	return nil
 }
 
 // Mute silences the mic

--- a/pkg/audio/replay/replay.go
+++ b/pkg/audio/replay/replay.go
@@ -106,8 +106,6 @@ func (c *Client) Stream(w io.Writer) error {
 			klog.V(7).Infof("io.Writer succeeded. Bytes written: %d\n", byteCount)
 		}
 	}
-
-	return nil
 }
 
 // Mute silences the replay device

--- a/pkg/client/live/client.go
+++ b/pkg/client/live/client.go
@@ -239,7 +239,10 @@ func (c *Client) listen() {
 				}
 
 				if c.callback != nil {
-					c.router.Message(byMsg)
+					err := c.router.Message(byMsg)
+					if err != nil {
+						klog.V(1).Infof("WebSocketClient::listen: router.Message failed. Err: %v\n", err)
+					}
 				} else {
 					klog.V(7).Infof("WebSocketClient::listen: msg recv (type %d): %s\n", msgType, string(byMsg))
 				}
@@ -415,9 +418,7 @@ func (c *Client) closeWs() {
 func (c *Client) ping() {
 	klog.V(6).Infof("live.ping() ENTER\n")
 
-	var counter uint64
-	counter = 0
-
+	counter := 0
 	ticker := time.NewTicker(pingPeriod)
 	defer ticker.Stop()
 	for {

--- a/pkg/client/rest/debug.go
+++ b/pkg/client/rest/debug.go
@@ -70,7 +70,10 @@ func (d *debugRoundTrip) debugRequest(req *http.Request) string {
 	// Capture headers
 	var wc io.WriteCloser = d.newFile("req.headers")
 	b, _ := httputil.DumpRequest(req, false)
-	wc.Write(b)
+	_, err := wc.Write(b)
+	if err != nil {
+		d.logf("Error writing request headers: %v", err)
+	}
 	wc.Close()
 
 	ext := d.ext(req.Header)
@@ -94,7 +97,10 @@ func (d *debugRoundTrip) debugResponse(res *http.Response, ext string) {
 	// Capture headers
 	var wc io.WriteCloser = d.newFile("res.headers")
 	b, _ := httputil.DumpResponse(res, false)
-	wc.Write(b)
+	_, err := wc.Write(b)
+	if err != nil {
+		d.logf("Error writing response headers: %v", err)
+	}
 	wc.Close()
 
 	// Capture body

--- a/pkg/client/rest/debug/file.go
+++ b/pkg/client/rest/debug/file.go
@@ -21,7 +21,7 @@ type FileProvider struct {
 	files []*os.File
 }
 
-func (fp FileProvider) NewFile(p string) io.WriteCloser {
+func (fp *FileProvider) NewFile(p string) io.WriteCloser {
 	f, err := os.Create(path.Join(fp.Path, p))
 	if err != nil {
 		panic(err)
@@ -34,7 +34,7 @@ func (fp FileProvider) NewFile(p string) io.WriteCloser {
 	return NewFileWriterCloser(f, p)
 }
 
-func (fp FileProvider) Flush() {
+func (fp *FileProvider) Flush() {
 	fp.mu.Lock()
 	defer fp.mu.Unlock()
 	for _, f := range fp.files {

--- a/pkg/common/init.go
+++ b/pkg/common/init.go
@@ -9,6 +9,7 @@ package common
 
 import (
 	"flag"
+	"fmt"
 	"strconv"
 
 	klog "k8s.io/klog/v2"
@@ -57,10 +58,19 @@ func Init(init InitLib) {
 	}
 
 	klog.InitFlags(nil)
-	flag.Set("v", strconv.FormatInt(int64(init.LogLevel), 10))
+	err := flag.Set("v", strconv.FormatInt(int64(init.LogLevel), 10))
+	if err != nil {
+		fmt.Printf("Error setting log level: %v", err)
+	}
 	if init.DebugFilePath != "" {
-		flag.Set("logtostderr", "false")
-		flag.Set("log_file", init.DebugFilePath)
+		err = flag.Set("logtostderr", "false")
+		if err != nil {
+			fmt.Printf("Error setting logtostderr: %v", err)
+		}
+		err = flag.Set("log_file", init.DebugFilePath)
+		if err != nil {
+			fmt.Printf("Error setting log_file: %v", err)
+		}
 	}
 	flag.Parse()
 }

--- a/tests/prerecorded_test.go
+++ b/tests/prerecorded_test.go
@@ -24,7 +24,6 @@ func TestPrerecordedFromURL(t *testing.T) {
 
 	const preRecordedEndPoint = "https://api.deepgram.com/v1/listen"
 	const betaEndPoint = "https://beta.api.deepgram.com/v1/listen"
-	const betaHost = "beta.api.deepgram.com"
 
 	// Specify query params that are acceptable. A nil means no check
 	var acceptParams = map[string][]string{
@@ -107,7 +106,7 @@ func TestPrerecordedFromURL(t *testing.T) {
 		}
 
 		// Based on query parameters, send Mock responses
-		var resp = &http.Response{}
+		var resp *http.Response
 		if options.Get("summarize") == "v2" {
 			resp = httpmock.NewStringResponse(200, MockSummarizeV2Response)
 		} else if options.Get("summarize") == "true" {


### PR DESCRIPTION
## Proposed changes

Running [golangci-lint](https://github.com/golangci/golangci-lint) locally gave the following issues:
```
vonthd@vonthds-MacBook-Pro-2:deepgram-go-sdk$ ./golangci-lint run -v --timeout=5m
INFO [config_reader] Config search paths: [./ /Users/vonthd/go/src/github.com/deepgram/deepgram-go-sdk /Users/vonthd/go/src/github.com/deepgram /Users/vonthd/go/src/github.com /Users/vonthd/go/src /Users/vonthd/go /Users/vonthd /Users /] 
INFO [lintersdb] Active 6 linters: [errcheck gosimple govet ineffassign staticcheck unused] 
INFO [loader] Go packages loading at mode 575 (name|files|deps|exports_file|imports|types_sizes|compiled_files) took 2.427023375s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 4.248833ms 
INFO [linters_context/goanalysis] analyzers took 3.777163166s with top 10 stages: buildir: 2.48945779s, fact_deprecated: 132.105752ms, inspect: 119.256166ms, printf: 99.218042ms, ctrlflow: 95.353338ms, typedness: 83.638585ms, nilness: 79.823918ms, fact_purity: 78.924374ms, SA5012: 66.472581ms, S1038: 39.283832ms 
INFO [runner/skip_dirs] Skipped 1 issues from dir examples/streaming/replay by pattern (^|/)examples($|/) 
INFO [runner/skip_dirs] Skipped 2 issues from dir examples/streaming/http by pattern (^|/)examples($|/) 
INFO [runner/skip_dirs] Skipped 1 issues from dir examples/streaming/microphone by pattern (^|/)examples($|/) 
INFO [runner/skip_dirs] Skipped 1 issues from dir examples/prerecorded/stream by pattern (^|/)examples($|/) 
INFO [runner/max_same_issues] 5/8 issues with text "composites: github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces.StatusError struct literal uses unkeyed fields" were hidden, use --max-same-issues 
INFO [runner] Issues before processing: 37, after processing: 19 
INFO [runner] Processors filtering stat (out/in): skip_files: 37/37, skip_dirs: 32/37, autogenerated_exclude: 32/32, exclude-rules: 24/32, severity-rules: 19/19, path_prettifier: 37/37, exclude: 32/32, max_per_file_from_linter: 24/24, path_shortener: 19/19, fixer: 19/19, sort_results: 19/19, cgo: 37/37, diff: 24/24, max_from_linter: 19/19, path_prefixer: 19/19, filename_unadjuster: 37/37, identifier_marker: 32/32, nolint: 24/24, uniq_by_line: 24/24, max_same_issues: 19/24, source_code: 19/19 
INFO [runner] processing took 3.192707ms with stages: nolint: 1.303083ms, exclude-rules: 598.583µs, path_prettifier: 494.501µs, identifier_marker: 340.458µs, autogenerated_exclude: 198.083µs, source_code: 135.583µs, skip_dirs: 97.417µs, max_same_issues: 12.958µs, uniq_by_line: 3.25µs, path_shortener: 2.041µs, cgo: 1.75µs, max_from_linter: 1.709µs, filename_unadjuster: 959ns, max_per_file_from_linter: 916ns, skip_files: 334ns, severity-rules: 291ns, diff: 209ns, fixer: 208ns, exclude: 207ns, sort_results: 125ns, path_prefixer: 42ns 
INFO [runner] linters took 1.093916292s with stages: goanalysis_metalinter: 1.090673375s 
pkg/common/init.go:60:10: Error return value of `flag.Set` is not checked (errcheck)
	flag.Set("v", strconv.FormatInt(int64(init.LogLevel), 10))
	        ^
pkg/common/init.go:62:11: Error return value of `flag.Set` is not checked (errcheck)
		flag.Set("logtostderr", "false")
		        ^
pkg/common/init.go:63:11: Error return value of `flag.Set` is not checked (errcheck)
		flag.Set("log_file", init.DebugFilePath)
		        ^
pkg/audio/microphone/microphone.go:20:22: Error return value of `portaudio.Initialize` is not checked (errcheck)
	portaudio.Initialize()
	                    ^
pkg/audio/microphone/microphone.go:25:21: Error return value of `portaudio.Terminate` is not checked (errcheck)
	portaudio.Terminate()
	                   ^
pkg/client/rest/debug.go:73:10: Error return value of `wc.Write` is not checked (errcheck)
	wc.Write(b)
	        ^
pkg/client/rest/debug.go:97:10: Error return value of `wc.Write` is not checked (errcheck)
	wc.Write(b)
	        ^
pkg/client/live/client.go:242:22: Error return value of `c.router.Message` is not checked (errcheck)
					c.router.Message(byMsg)
					                ^
pkg/api/live/v1/default.go:22:2: field `sb` is unused (unused)
	sb strings.Builder
	^
tests/prerecorded_test.go:27:8: const `betaHost` is unused (unused)
	const betaHost = "beta.api.deepgram.com"
	      ^
pkg/client/live/client.go:418:2: S1021: should merge variable declaration with assignment on next line (gosimple)
	var counter uint64
	^
pkg/client/rest/rest.go:84:13: composites: github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces.StatusError struct literal uses unkeyed fields (govet)
				return &interfaces.StatusError{res}
				        ^
pkg/client/rest/rest.go:89:12: composites: github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces.StatusError struct literal uses unkeyed fields (govet)
			return &interfaces.StatusError{res}
			        ^
pkg/client/prerecorded/client.go:162:13: composites: github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces.StatusError struct literal uses unkeyed fields (govet)
				return &interfaces.StatusError{res}
				        ^
pkg/client/rest/debug/file.go:24:10: copylocks: NewFile passes lock by value: github.com/deepgram/deepgram-go-sdk/pkg/client/rest/debug.FileProvider contains sync.Mutex (govet)
func (fp FileProvider) NewFile(p string) io.WriteCloser {
         ^
pkg/client/rest/debug/file.go:37:10: copylocks: Flush passes lock by value: github.com/deepgram/deepgram-go-sdk/pkg/client/rest/debug.FileProvider contains sync.Mutex (govet)
func (fp FileProvider) Flush() {
         ^
pkg/audio/microphone/microphone.go:103:2: unreachable: unreachable code (govet)
	return nil
	^
pkg/audio/replay/replay.go:110:2: unreachable: unreachable code (govet)
	return nil
	^
tests/prerecorded_test.go:110:7: ineffectual assignment to resp (ineffassign)
		var resp = &http.Response{}
		    ^
INFO File cache stats: 10 entries of total size 48.9KiB 
INFO Memory: 37 samples, avg is 106.6MB, max is 406.4MB 
INFO Execution took 3.531797209s    
```

This PR addresses the issues found by the linter. Verified all `examples` work as expected.

TODO: for a future PR, this will be incorporated into a GitHub action.

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

NA
