### PR TITLE
Example on Sending Custom Param/Header

### DIFF
--- a/examples/prerecorded/file/main.go
+++ b/examples/prerecorded/file/main.go
@@ -13,6 +13,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
 	prerecorded "github.com/deepgram/deepgram-go-sdk/pkg/api/prerecorded/v1"
+	cfginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
 	client "github.com/deepgram/deepgram-go-sdk/pkg/client/prerecorded"
 )
@@ -32,15 +33,25 @@ func main() {
 
 	// set the Transcription options
 	options := interfaces.PreRecordedTranscriptionOptions{
-		Punctuate:  true,
-		Diarize:    true,
-		Language:   "en-US",
-		Utterances: true,
+		Punctuate: true,
+		Diarize:   true,
+		Language:  "en-US",
+		// Utterances: true, // Commenting this out to demonstrate how to send a custom parameter
 	}
 
 	// create a Deepgram client
 	c := client.NewWithDefaults()
 	dg := prerecorded.New(c)
+
+	// example on how to send a custom header
+	headers := make(map[string][]string, 0)
+	headers["MY-CUSTOM-HEADER"] = []string{"CUSTOM"}
+	ctx = cfginterfaces.WithCustomHeaders(ctx, headers)
+
+	// example on how to send a custom parameter
+	params := make(map[string][]string, 0)
+	params["utterances"] = []string{"true"}
+	ctx = cfginterfaces.WithCustomParameters(ctx, params)
 
 	// send/process file to Deepgram
 	res, err := dg.FromFile(ctx, filePath, options)


### PR DESCRIPTION
## Proposed changes

This is an example on sending a custom query parameter and a custom header for a given REST API call. Since these are custom, by definition there is zero error checking that happens.

```
// example on how to send a custom header
headers := make(map[string][]string, 0)
headers["MY-CUSTOM-HEADER"] = []string{"CUSTOM"}
ctx = cfginterfaces.WithCustomHeaders(ctx, headers)

// example on how to send a custom parameter
params := make(map[string][]string, 0)
params["utterances"] = []string{"true"}
ctx = cfginterfaces.WithCustomParameters(ctx, params)
```

 If you enable verbose debugging, this is what it looks like then under the covers:

```
I1214 06:41:45.807373    4217 client.go:131] Connecting to https://api.deepgram.com/v1/listen?diarize=true&language=en-US&punctuate=true&utterances=true
I1214 06:41:45.807446    4217 client.go:143] Custom Header: MY-CUSTOM-HEADER = CUSTOM
```

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

NA
