### PR TITLE
Implements `vad_events` for SpeechStarted

### DIFF
--- a/examples/streaming/microphone/main.go
+++ b/examples/streaming/microphone/main.go
@@ -28,7 +28,7 @@ func (c MyCallback) Message(mr *api.MessageResponse) error {
 	if len(mr.Channel.Alternatives) == 0 || len(sentence) == 0 {
 		return nil
 	}
-	fmt.Printf("\n%s\n", sentence)
+	fmt.Printf("\nspeaker: %s\n", sentence)
 	return nil
 }
 
@@ -38,6 +38,11 @@ func (c MyCallback) Metadata(md *api.MetadataResponse) error {
 	fmt.Printf("Metadata.RequestID: %s\n", strings.TrimSpace(md.RequestID))
 	fmt.Printf("Metadata.Channels: %d\n", md.Channels)
 	fmt.Printf("Metadata.Created: %s\n\n", strings.TrimSpace(md.Created))
+	return nil
+}
+
+func (c MyCallback) SpeechStarted(ssr *api.SpeechStartedResponse) error {
+	fmt.Printf("\n[SpeechStarted] Received\n")
 	return nil
 }
 
@@ -85,8 +90,9 @@ func main() {
 		SampleRate:  16000,
 		SmartFormat: true,
 		// To get UtteranceEnd, the following must be set:
-		// InterimResults: true,
-		// UtteranceEndMs: "1000",
+		InterimResults: true,
+		UtteranceEndMs: "1000",
+		VadEvents:      true,
 	}
 
 	// example on how to send a custom parameter

--- a/pkg/api/live/v1/default.go
+++ b/pkg/api/live/v1/default.go
@@ -95,6 +95,41 @@ func (dch DefaultCallbackHandler) Metadata(md *interfaces.MetadataResponse) erro
 	return nil
 }
 
+func (dch DefaultCallbackHandler) SpeechStarted(ssr *interfaces.SpeechStartedResponse) error {
+	var debugStr string
+	if v := os.Getenv("DEEPGRAM_DEBUG"); v != "" {
+		klog.V(4).Infof("DEEPGRAM_DEBUG found")
+		debugStr = v
+	}
+
+	if strings.Compare(strings.ToLower(debugStr), "true") == 0 {
+		data, err := json.Marshal(ssr)
+		if err != nil {
+			klog.V(1).Infof("SpeechStarted json.Marshal failed. Err: %v\n", err)
+			return err
+		}
+
+		prettyJson, err := prettyjson.Format(data)
+		if err != nil {
+			klog.V(1).Infof("prettyjson.Marshal failed. Err: %v\n", err)
+			return err
+		}
+		klog.V(2).Infof("\n\nSpeechStarted Object:\n%s\n\n", prettyJson)
+
+		return nil
+	}
+
+	// handle the message
+	fmt.Printf("\nSpeechStarted.Timestamp: %f\n", ssr.Timestamp)
+	fmt.Printf("SpeechStarted.Channels:\n")
+	for _, val := range ssr.Channel {
+		fmt.Printf("\tChannel: %d\n", val)
+	}
+	fmt.Printf("\n")
+
+	return nil
+}
+
 func (dch DefaultCallbackHandler) UtteranceEnd(ur *interfaces.UtteranceEndResponse) error {
 	fmt.Printf("\nUtteranceEnd\n")
 	return nil

--- a/pkg/api/live/v1/interfaces/constants.go
+++ b/pkg/api/live/v1/interfaces/constants.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Copyright 2023-2024 Deepgram SDK contributors. All Rights Reserved.
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
@@ -7,9 +7,10 @@ package interfaces
 // These are the message types that can be received from the live API
 const (
 	// message types
-	TypeMessageResponse      string = "Results"
-	TypeMetadataResponse     string = "Metadata"
-	TypeUtteranceEndResponse string = "UtteranceEnd"
+	TypeMessageResponse       string = "Results"
+	TypeMetadataResponse      string = "Metadata"
+	TypeUtteranceEndResponse  string = "UtteranceEnd"
+	TypeSpeechStartedResponse string = "SpeechStarted"
 
 	// Error type
 	TypeErrorResponse string = "Error"

--- a/pkg/api/live/v1/interfaces/interfaces.go
+++ b/pkg/api/live/v1/interfaces/interfaces.go
@@ -9,6 +9,7 @@ package interfaces
 type LiveMessageCallback interface {
 	Message(mr *MessageResponse) error
 	Metadata(md *MetadataResponse) error
+	SpeechStarted(ssr *SpeechStartedResponse) error
 	UtteranceEnd(ur *UtteranceEndResponse) error
 	Error(er *ErrorResponse) error
 	// TODO: implement other conversation insights

--- a/pkg/api/live/v1/interfaces/types.go
+++ b/pkg/api/live/v1/interfaces/types.go
@@ -78,6 +78,12 @@ type UtteranceEndResponse struct {
 	LastWordEnd float64 `json:"last_word_end,omitempty"`
 }
 
+type SpeechStartedResponse struct {
+	Type      string  `json:"type,omitempty"`
+	Channel   []int   `json:"channel,omitempty"`
+	Timestamp float64 `json:"timestamp,omitempty"`
+}
+
 // ErrorResponse is the response from a live transcription
 type ErrorResponse struct {
 	Description string `json:"description"`

--- a/pkg/api/live/v1/router.go
+++ b/pkg/api/live/v1/router.go
@@ -65,6 +65,8 @@ func (r *MessageRouter) Message(byMsg []byte) error {
 		err = r.MessageResponse(byMsg)
 	case interfaces.TypeMetadataResponse:
 		err = r.MetadataResponse(byMsg)
+	case interfaces.TypeSpeechStartedResponse:
+		err = r.SpeechStartedResponse(byMsg)
 	case interfaces.TypeUtteranceEndResponse:
 		err = r.UtteranceEndResponse(byMsg)
 	case interfaces.TypeErrorResponse:
@@ -146,6 +148,37 @@ func (r *MessageRouter) MetadataResponse(byMsg []byte) error {
 
 	klog.V(1).Infof("User callback is undefined\n")
 	klog.V(6).Infof("router.MetadataResponse ENTER\n")
+
+	return nil
+}
+
+func (r *MessageRouter) SpeechStartedResponse(byMsg []byte) error {
+	klog.V(6).Infof("router.SpeechStartedResponse ENTER\n")
+
+	// trace debugging
+	r.printDebugMessages(5, "SpeechStartedResponse", byMsg)
+
+	var ssr interfaces.SpeechStartedResponse
+	err := json.Unmarshal(byMsg, &ssr)
+	if err != nil {
+		klog.V(1).Infof("SpeechStartedResponse json.Unmarshal failed. Err: %v\n", err)
+		klog.V(6).Infof("router.SpeechStartedResponse LEAVE\n")
+		return err
+	}
+
+	if r.callback != nil {
+		err := r.callback.SpeechStarted(&ssr)
+		if err != nil {
+			klog.V(1).Infof("callback.SpeechStartedResponse failed. Err: %v\n", err)
+		} else {
+			klog.V(5).Infof("callback.SpeechStartedResponse succeeded\n")
+		}
+		klog.V(6).Infof("router.SpeechStartedResponse LEAVE\n")
+		return err
+	}
+
+	klog.V(1).Infof("User callback is undefined\n")
+	klog.V(6).Infof("router.SpeechStartedResponse ENTER\n")
 
 	return nil
 }

--- a/pkg/client/interfaces/types-stream.go
+++ b/pkg/client/interfaces/types-stream.go
@@ -36,5 +36,6 @@ type LiveTranscriptionOptions struct {
 	SmartFormat     bool     `json:"smart_format,omitempty" url:"smart_format,omitempty"`
 	Tag             []string `json:"tag,omitempty" url:"tag,omitempty"`
 	UtteranceEndMs  string   `json:"utterance_end_ms,omitempty" url:"utterance_end_ms,omitempty"`
+	VadEvents       bool     `json:"vad_events,omitempty" url:"vad_events,omitempty"`
 	Version         string   `json:"version,omitempty" url:"version,omitempty"`
 }


### PR DESCRIPTION
## Proposed changes

This implements `vad_events` in order to trigger speech started events.

The `examples/streaming/microphone` example has been updated to test the functionality.

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

NA
