### PR TITLE
EOF error logging with lower verbosity level

### DIFF
--- a/pkg/client/live/client.go
+++ b/pkg/client/live/client.go
@@ -262,8 +262,12 @@ func (c *Client) Stream(r io.Reader) error {
 			return nil
 		default:
 			bytesRead, err := r.Read(chunk)
-			if err != nil {
-				klog.V(1).Infof("r.Read failed. Err: %v\n", err)
+			if err == io.EOF && !c.retry {
+				klog.V(3).Infof("stream object EOF\n")
+				klog.V(6).Infof("live.Stream() LEAVE\n")
+				return nil
+			} else if err != nil {
+				klog.V(1).Infof("r.Read encountered EOF. Err: %v\n", err)
 				klog.V(6).Infof("live.Stream() LEAVE\n")
 				return err
 			}


### PR DESCRIPTION
## Proposed changes

This change handles an EOF condition more gracefully in the `live.Stream()` function by logging it with a lower verbosity level (V(4)) rather than treating it as a regular error (V(1)). 

Instead of:
`klog.V(1).Infof("r.Read failed. Err: %v\n", err)`

It logs:
`klog.V(4).Infof("r.Read encountered EOF. Err: %v\n", err)`