### PR TITLE
adds extra feature to metadata types

### DIFF
--- a/pkg/api/live/v1/interfaces/types.go
+++ b/pkg/api/live/v1/interfaces/types.go
@@ -69,6 +69,7 @@ type MetadataResponse struct {
 	Sha256         string               `json:"sha256,omitempty"`
 	TransactionKey string               `json:"transaction_key,omitempty"`
 	Type           string               `json:"type,omitempty"`
+	Extra          map[string]string    `json:"extra,omitempty"`
 }
 
 // UtteranceEndResponse is the response from a live transcription

--- a/pkg/api/prerecorded/v1/interfaces/types.go
+++ b/pkg/api/prerecorded/v1/interfaces/types.go
@@ -51,6 +51,7 @@ type Metadata struct {
 	IntentsInfo    IntentsInfo          `json:"intents_info,omitempty"`
 	SentimentInfo  SentimentInfo        `json:"sentiment_info,omitempty"`
 	TopicsInfo     TopicsInfo           `json:"topics_info,omitempty"`
+	Extra          map[string]string    `json:"extra,omitempty"`
 }
 
 type Warning struct {


### PR DESCRIPTION
## Proposed changes
The feature Extra had not been added to prerecorded or live `v1/interfaces/types` so I added it as the type `map[string]interface{}`. The user can add it as a string like this:

```go
options := interfaces.LiveTranscriptionOptions{
	Extra:      "test:one",
	}
```


## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

