### PR TITLE
fix: type mismatch in client options

### DIFF
--- a/pkg/client/analyze/client.go
+++ b/pkg/client/analyze/client.go
@@ -58,7 +58,7 @@ func New(apiKey string, options *interfaces.ClientOptions) *Client {
 	}
 
 	c := Client{
-		Client:   rest.New(options),
+		Client:   rest.New(*options),
 		cOptions: options,
 	}
 	return &c


### PR DESCRIPTION
## Proposed changes
Dereferences the pointer before passing it to the function, like this: `rest.New(*options)`


## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

