### PR TITLE
Properly handle success result for live stream

### DIFF
--- a/pkg/client/live/client.go
+++ b/pkg/client/live/client.go
@@ -353,6 +353,8 @@ func (c *Client) Stream(r io.Reader) error {
 		default:
 			bytesRead, err := r.Read(chunk)
 			switch {
+			case err == nil:
+				// do nothing
 			case strings.Contains(err.Error(), FatalReadSocketErr):
 				klog.V(1).Infof("Fatal socket error: %v\n", err)
 				klog.V(6).Infof("live.listen() LEAVE\n")


### PR DESCRIPTION
## Proposed changes
This PR fixes error handling inside `func (c *Client) Stream(r io.Reader) error` function.
The current implementation tries to call `err.Error()` in the first switch `case strings.Contains(err.Error(), FatalReadSocketErr)`.
It leads to a panic in case of handling successful results.

```

[Open] Received
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x7d94e3]

goroutine 353 [running]:
github.com/deepgram/deepgram-go-sdk/pkg/client/live.(*Client).Stream(0xc000400600, {0xf879a0, 0xc0007b6180})
        .../go/pkg/mod/github.com/deepgram/deepgram-go-sdk@v1.3.0/pkg/client/live/client.go:356 +0x103

```


## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

