### PR TITLE
Fix Open/Close Event Pairing After Fatal Reconnect Refactor

### DIFF
--- a/tests/edge_cases/cancel/main.go
+++ b/tests/edge_cases/cancel/main.go
@@ -16,7 +16,9 @@ import (
 
 func main() {
 	// init library
-	client.InitWithDefault()
+	client.Init(client.InitLib{
+		LogLevel: client.LogLevelTrace, // LogLevelDefault, LogLevelFull, LogLevelDebug, LogLevelTrace
+	})
 
 	// Go context
 	ctx := context.Background()


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This fixes an issue with the last PR https://github.com/deepgram/deepgram-go-sdk/pull/232 which even OpenResponse didn't have a corresponding CloseResponse.

This also fixes:
- an outstanding issue where the listen thread would take a while to disconnect after the socket was gone
- fires ErrorResponses for Deepgram, Fatal, etc type error messages

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA