### PR TITLE
Fix README: pass options as pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ c := client.NewWithDefaults()
 dg := prerecorded.New(c)
 
 // transcription options
-options := PreRecordedTranscriptionOptions{
+options := &interfaces.PreRecordedTranscriptionOptions{
     Punctuate:  true,
     Diarize:    true,
     Language:   "en-US",
@@ -108,7 +108,7 @@ You can find a [walkthrough](https://developers.deepgram.com/docs/live-streaming
 
 ```go
 // options
-transcriptOptions := interfaces.LiveTranscriptionOptions{
+transcriptOptions := &interfaces.LiveTranscriptionOptions{
     Language:    "en-US",
     Punctuate:   true,
     Encoding:    "linear16",


### PR DESCRIPTION
## Proposed changes

Update README examples to pass option structs as pointers, as is expected by
the API.

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated code examples in the README to reflect changes in how options structures are declared, now using pointers for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->