### PR TITLE
include deepgram specific error message in StatusError.Error

### DIFF
--- a/pkg/client/interfaces/v1/utils.go
+++ b/pkg/client/interfaces/v1/utils.go
@@ -95,5 +95,8 @@ type StatusError struct {
 
 // Error string representation for a given error
 func (e *StatusError) Error() string {
+	if e.DeepgramError != nil && e.DeepgramError.ErrMsg != "" {
+		return fmt.Sprintf("%s %s: %s - %s", e.Resp.Request.Method, e.Resp.Request.URL, e.Resp.Status, e.DeepgramError.ErrMsg)
+	}
 	return fmt.Sprintf("%s %s: %s", e.Resp.Request.Method, e.Resp.Request.URL, e.Resp.Status)
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

This PR adds the additional Deepgram-specific error message to the `StatusError.Error` function, if present. The goal behind this change is to provide additional details to consumers of the SDK (for example the reason why a 400 error was returned). For example, the following error does not explain what was wrong with the request:
```
POST https://api.deepgram.com/v1/listen: 400 Bad Request
```

With the changes in this PR, the above would be returned as something like:
```
POST https://api.deepgram.com/v1/listen: 400 Bad Request - Bad Request: No such model/version combination found.
```

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

It's possible to check the returned error type and get these details within the calling code, but ideally the error message itself contains enough details to know what went wrong. Open to thoughts from the team if there are better options here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error reporting for `StatusError` to provide more detailed information when a `DeepgramError` is present.
	- Improved clarity of error messages by including HTTP request method, URL, and response status when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->