### PR TITLE
add functions for proxy on adjust headers

### DIFF
--- a/pkg/client/common/v1/websocket.go
+++ b/pkg/client/common/v1/websocket.go
@@ -159,6 +159,9 @@ func (c *WSClient) internalConnectWithCancel(ctx context.Context, ctxCancel cont
 	myHeader.Set("Host", c.cOptions.Host)
 	myHeader.Set("Authorization", "token "+c.cOptions.APIKey)
 	myHeader.Set("User-Agent", clientinterfaces.DgAgent)
+	if c.cOptions.WSHeaderProcessor != nil {
+		c.cOptions.WSHeaderProcessor(myHeader)
+	}
 
 	// attempt to establish connection
 	i := int64(0)
@@ -196,6 +199,7 @@ func (c *WSClient) internalConnectWithCancel(ctx context.Context, ctxCancel cont
 			dialer = websocket.Dialer{
 				HandshakeTimeout: 15 * time.Second,
 				RedirectService:  c.cOptions.RedirectService,
+				Proxy:            c.cOptions.Proxy,
 			}
 		} else {
 			dialer = websocket.Dialer{
@@ -204,6 +208,7 @@ func (c *WSClient) internalConnectWithCancel(ctx context.Context, ctxCancel cont
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: c.cOptions.SkipServerAuth},
 				RedirectService: c.cOptions.RedirectService,
 				SkipServerAuth:  c.cOptions.SkipServerAuth,
+				Proxy:           c.cOptions.Proxy,
 			}
 		}
 		// perform the websocket connection

--- a/pkg/client/interfaces/v1/types-client.go
+++ b/pkg/client/interfaces/v1/types-client.go
@@ -4,13 +4,20 @@
 
 package interfacesv1
 
+import (
+	"net/http"
+	"net/url"
+)
+
 // ClientOptions defines any options for the client
 type ClientOptions struct {
-	APIKey     string
-	Host       string // override for the host endpoint
-	APIVersion string // override for the version used
-	Path       string // override for the endpoint path usually <version/listen> or <version/projects>
-	SelfHosted bool   // set to true if using on-prem
+	APIKey            string
+	Host              string                                // override for the host endpoint
+	APIVersion        string                                // override for the version used
+	Path              string                                // override for the endpoint path usually <version/listen> or <version/projects>
+	SelfHosted        bool                                  // set to true if using on-prem
+	Proxy             func(*http.Request) (*url.URL, error) // provide function for proxy -- e.g. http.ProxyFromEnvironment
+	WSHeaderProcessor func(http.Header)                     // process headers before dialing for websocket connection
 
 	// shared client options
 	SkipServerAuth bool // keeps the client from authenticating with the server


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
When operating Deepgram on-premises in a k8s environment using istio service-mesh, the websocket handshake fails to complete with the standard setup.  In our environment the proxy configuration options are provided via the standard environment variables, so resolving the proxy via the golang net/http standard function performs the proper proxy configuration.  The presence of the "Host" header still prevents a successful websocket setup to be established, but rather than simply remove that header, providing the ability of the caller to modify headers prior to websocket setup appeared a preferable solution .

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

