### PR TITLE
Add "Clear" function to Speak Websocket clients

### DIFF
--- a/pkg/client/speak/v1/websocket/client_callback.go
+++ b/pkg/client/speak/v1/websocket/client_callback.go
@@ -168,6 +168,24 @@ func (c *WSCallback) Flush() error {
 	return err
 }
 
+// Clear will instruct the server to clear the current text buffer
+func (c *WSCallback) Clear() error {
+	klog.V(6).Infof("speak.Clear() ENTER\n")
+
+	err := c.WriteJSON(controlMessage{Type: MessageTypeClear})
+	if err != nil {
+		klog.V(1).Infof("Clear failed. Err: %v\n", err)
+		klog.V(6).Infof("speak.Clear() LEAVE\n")
+
+		return err
+	}
+
+	klog.V(4).Infof("Clear Succeeded\n")
+	klog.V(6).Infof("speak.Clear() LEAVE\n")
+
+	return err
+}
+
 // Reset will instruct the server to reset the current buffer
 func (c *WSCallback) Reset() error {
 	klog.V(6).Infof("speak.Reset() ENTER\n")

--- a/pkg/client/speak/v1/websocket/client_channel.go
+++ b/pkg/client/speak/v1/websocket/client_channel.go
@@ -167,6 +167,24 @@ func (c *WSChannel) Flush() error {
 	return err
 }
 
+// Clear will instruct the server to clear the current text buffer
+func (c *WSChannel) Clear() error {
+	klog.V(6).Infof("speak.Clear() ENTER\n")
+
+	err := c.WriteJSON(controlMessage{Type: MessageTypeClear})
+	if err != nil {
+		klog.V(1).Infof("Clear failed. Err: %v\n", err)
+		klog.V(6).Infof("speak.Clear() LEAVE\n")
+
+		return err
+	}
+
+	klog.V(4).Infof("Clear Succeeded\n")
+	klog.V(6).Infof("speak.Clear() LEAVE\n")
+
+	return err
+}
+
 // Reset will instruct the server to reset the current buffer
 func (c *WSChannel) Reset() error {
 	klog.V(6).Infof("speak.Reset() ENTER\n")

--- a/pkg/client/speak/v1/websocket/constants.go
+++ b/pkg/client/speak/v1/websocket/constants.go
@@ -27,6 +27,9 @@ const (
 	// MessageTypeFlush flushes the audio from the server
 	MessageTypeFlush string = "Flush"
 
+	// MessageTypeClear clears the audio from the server
+	MessageTypeClear string = "Clear"
+
 	// MessageTypeReset resets the text buffer
 	MessageTypeReset string = "Reset"
 


### PR DESCRIPTION
## Proposed changes
Adds a function that will call the Clear command message on the Speak channel and callback websocket clients.
This functionality already appears to work using `WriteJSON` with Type as Clear, this change is just a helper function to codify that (as has been done for Flush, Reset, etc)


## Types of changes

What types of changes does your code introduce to the community Go SDK?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] (Not applicable?) I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
