### PR TITLE
"Fix: Avoid double-wrapping JSON in DoStream"

### DIFF
--- a/pkg/client/analyze/v1/client.go
+++ b/pkg/client/analyze/v1/client.go
@@ -143,12 +143,33 @@ func (c *Client) DoText(ctx context.Context, text string, options *interfaces.An
 	}
 
 	var buf bytes.Buffer
+	var tmp map[string]interface{}
+	isValidJSON := false
+
+	if err := json.Unmarshal([]byte(text), &tmp); err == nil {
+		// It's valid JSON, now check if it already contains a "text" field
+		if val, exists := tmp["Text"]; exists && val != nil {
+			isValidJSON = true
+		}
+	}
+
+	if isValidJSON {
+		klog.V(6).Infof("Is Already JSON \n")
+		_,err = buf.WriteString(text)
+		if err != nil {
+			klog.V(1).Infof("JSON WriteString failed. Err: %v\n", err)
+			klog.V(6).Infof("speak.DoText() LEAVE\n")
+			return err
+		}
+		
+	} else {
 	err = json.NewEncoder(&buf).Encode(textSource{Text: text})
 	if err != nil {
 		klog.V(1).Infof("json.NewEncoder().Encode() failed. Err: %v\n", err)
 		klog.V(6).Infof("speak.DoText() LEAVE\n")
 		return err
 	}
+}
 
 	// using the Common SetupRequest (c.SetupRequest vs c.RESTClient.SetupRequest) method which
 	// also sets the common headers including the content-type (for example)


### PR DESCRIPTION
## Proposed changes
Stream is now checked if it already a JSON and avoiding Double-Wrapping the JSON.


## Types of changes
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

- [ X ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Considered creating another Function DoJSON but it is not needed as the change is very subtle. 

