### PR TITLE
fix: change module path so go will let us publish

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -20,15 +20,15 @@
 package sdk
 
 import (
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/client/analyze"
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/analyze"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/api/analyze/v1"
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket"
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/rest"
-	_ "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/analyze/v1"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/rest"
+	_ "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket"
 )

--- a/examples/agent/websocket/no_mic/main.go
+++ b/examples/agent/websocket/no_mic/main.go
@@ -17,9 +17,9 @@ import (
 	"sync"
 	"time"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/agent"
-	"github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/agent"
+	"github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 // MyHandler handles all websocket events

--- a/examples/agent/websocket/simple/main.go
+++ b/examples/agent/websocket/simple/main.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket/interfaces"
-	microphone "github.com/deepgram/deepgram-go-sdk/pkg/audio/microphone"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/agent"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket/interfaces"
+	microphone "github.com/deepgram/deepgram-go-sdk/v2/pkg/audio/microphone"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/agent"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 type MyHandler struct {

--- a/examples/analyze/intent/main.go
+++ b/examples/analyze/intent/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	analyze "github.com/deepgram/deepgram-go-sdk/pkg/api/analyze/v1"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/analyze"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	analyze "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/analyze/v1"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/analyze"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 const (

--- a/examples/analyze/sentiment/main.go
+++ b/examples/analyze/sentiment/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	analyze "github.com/deepgram/deepgram-go-sdk/pkg/api/analyze/v1"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/analyze"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	analyze "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/analyze/v1"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/analyze"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 const (

--- a/examples/analyze/summary/main.go
+++ b/examples/analyze/summary/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	analyze "github.com/deepgram/deepgram-go-sdk/pkg/api/analyze/v1"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/analyze"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	analyze "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/analyze/v1"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/analyze"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 const (

--- a/examples/analyze/topic/main.go
+++ b/examples/analyze/topic/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	analyze "github.com/deepgram/deepgram-go-sdk/pkg/api/analyze/v1"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/analyze"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	analyze "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/analyze/v1"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/analyze"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 const (

--- a/examples/auth/grant-token/main.go
+++ b/examples/auth/grant-token/main.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"os"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/auth/v1"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/auth"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/auth/v1"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/auth"
 )
 
 func main() {

--- a/examples/manage/balances/main.go
+++ b/examples/manage/balances/main.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"os"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
 )
 
 func main() {

--- a/examples/manage/invitations/main.go
+++ b/examples/manage/invitations/main.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"os"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
 )
 
 func main() {

--- a/examples/manage/keys/main.go
+++ b/examples/manage/keys/main.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"os"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
 )
 
 func main() {

--- a/examples/manage/members/main.go
+++ b/examples/manage/members/main.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"os"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
 )
 
 const (

--- a/examples/manage/models/main.go
+++ b/examples/manage/models/main.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"os"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
 )
 
 func main() {

--- a/examples/manage/projects/main.go
+++ b/examples/manage/projects/main.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"os"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
 )
 
 func main() {

--- a/examples/manage/scopes/main.go
+++ b/examples/manage/scopes/main.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"os"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
 )
 
 const (

--- a/examples/manage/usage/main.go
+++ b/examples/manage/usage/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
 )
 
 func main() {

--- a/examples/speech-to-text/rest/callback/callback/main.go
+++ b/examples/speech-to-text/rest/callback/callback/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (

--- a/examples/speech-to-text/rest/callback/endpoint/main.go
+++ b/examples/speech-to-text/rest/callback/endpoint/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gin-gonic/gin"
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest/interfaces"
 )
 
 type SampleProxy struct {

--- a/examples/speech-to-text/rest/file/main.go
+++ b/examples/speech-to-text/rest/file/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (
@@ -49,7 +49,7 @@ func main() {
 
 	// example on how to send a custom header
 	// need to import (
-	//	 "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	//	 "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 	// )
 	//
 	// headers := make(map[string][]string, 0)

--- a/examples/speech-to-text/rest/intent/main.go
+++ b/examples/speech-to-text/rest/intent/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (

--- a/examples/speech-to-text/rest/sentiment/main.go
+++ b/examples/speech-to-text/rest/sentiment/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (

--- a/examples/speech-to-text/rest/stream/main.go
+++ b/examples/speech-to-text/rest/stream/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (

--- a/examples/speech-to-text/rest/summary/main.go
+++ b/examples/speech-to-text/rest/summary/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (

--- a/examples/speech-to-text/rest/topic/main.go
+++ b/examples/speech-to-text/rest/topic/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (

--- a/examples/speech-to-text/rest/url/main.go
+++ b/examples/speech-to-text/rest/url/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (

--- a/examples/speech-to-text/websocket/http_callback/main.go
+++ b/examples/speech-to-text/websocket/http_callback/main.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"reflect"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (

--- a/examples/speech-to-text/websocket/http_channel/main.go
+++ b/examples/speech-to-text/websocket/http_channel/main.go
@@ -13,8 +13,8 @@ import (
 	"os"
 	"reflect"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 const (

--- a/examples/speech-to-text/websocket/microphone_callback/main.go
+++ b/examples/speech-to-text/websocket/microphone_callback/main.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"strings"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
-	microphone "github.com/deepgram/deepgram-go-sdk/pkg/audio/microphone"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
+	microphone "github.com/deepgram/deepgram-go-sdk/v2/pkg/audio/microphone"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 // Implement your own callback

--- a/examples/speech-to-text/websocket/microphone_channel/main.go
+++ b/examples/speech-to-text/websocket/microphone_channel/main.go
@@ -15,10 +15,10 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
-	microphone "github.com/deepgram/deepgram-go-sdk/pkg/audio/microphone"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
+	microphone "github.com/deepgram/deepgram-go-sdk/v2/pkg/audio/microphone"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 type MyHandler struct {

--- a/examples/speech-to-text/websocket/replay/main.go
+++ b/examples/speech-to-text/websocket/replay/main.go
@@ -12,9 +12,9 @@ import (
 	"log"
 	"os"
 
-	replay "github.com/deepgram/deepgram-go-sdk/pkg/audio/replay"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	replay "github.com/deepgram/deepgram-go-sdk/v2/pkg/audio/replay"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 func main() {

--- a/examples/speech-to-text/websocket/test/main.go
+++ b/examples/speech-to-text/websocket/test/main.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"time"
 
-	microphone "github.com/deepgram/deepgram-go-sdk/pkg/audio/microphone"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	microphone "github.com/deepgram/deepgram-go-sdk/v2/pkg/audio/microphone"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 func main() {

--- a/examples/text-to-speech/rest/file/hello-world/main.go
+++ b/examples/text-to-speech/rest/file/hello-world/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/examples/text-to-speech/rest/file/woodchuck/main.go
+++ b/examples/text-to-speech/rest/file/woodchuck/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/examples/text-to-speech/rest/stream/hello-world/main.go
+++ b/examples/text-to-speech/rest/stream/hello-world/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/examples/text-to-speech/rest/stream/woodchuck/main.go
+++ b/examples/text-to-speech/rest/stream/woodchuck/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/examples/text-to-speech/rest/writer/hello-world/main.go
+++ b/examples/text-to-speech/rest/writer/hello-world/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/examples/text-to-speech/rest/writer/woodchuck/main.go
+++ b/examples/text-to-speech/rest/writer/woodchuck/main.go
@@ -12,9 +12,9 @@ import (
 
 	prettyjson "github.com/hokaccha/go-prettyjson"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/examples/text-to-speech/websocket/interactive_callback/main.go
+++ b/examples/text-to-speech/websocket/interactive_callback/main.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	speak "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	speak "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/examples/text-to-speech/websocket/interactive_channel/main.go
+++ b/examples/text-to-speech/websocket/interactive_channel/main.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 	"time"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	speak "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	speak "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/examples/text-to-speech/websocket/simple_callback/main.go
+++ b/examples/text-to-speech/websocket/simple_callback/main.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
-	speak "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
+	speak "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/examples/text-to-speech/websocket/simple_channel/main.go
+++ b/examples/text-to-speech/websocket/simple_channel/main.go
@@ -12,9 +12,9 @@ import (
 	"sync"
 	"time"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
-	speak "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
+	speak "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/deepgram/deepgram-go-sdk
+module github.com/deepgram/deepgram-go-sdk/v2
 
 go 1.19
 

--- a/pkg/api/agent/v1/websocket/chan_default.go
+++ b/pkg/api/agent/v1/websocket/chan_default.go
@@ -14,7 +14,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket/interfaces"
 )
 
 // NewDefaultChanHandler creates a new DefaultChanHandler

--- a/pkg/api/agent/v1/websocket/chan_router.go
+++ b/pkg/api/agent/v1/websocket/chan_router.go
@@ -13,7 +13,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket/interfaces"
 )
 
 // NewWithDefault creates a ChanRouter with the default callback handler

--- a/pkg/api/agent/v1/websocket/interfaces/constants.go
+++ b/pkg/api/agent/v1/websocket/interfaces/constants.go
@@ -5,7 +5,7 @@
 package interfacesv1
 
 import (
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
 )
 
 // These are the message types that can be received from the live API
@@ -13,13 +13,13 @@ type TypeResponse commoninterfaces.TypeResponse
 
 // client message types
 const (
-	TypeSettings			  = "Settings"
-	TypeUpdatePrompt          = "UpdatePrompt"
-	TypeUpdateSpeak           = "UpdateSpeak"
-	TypeInjectAgentMessage    = "InjectAgentMessage"
-	TypeFunctionCallResponse  = "FunctionCallResponse"
-	TypeKeepAlive             = "KeepAlive"
-	TypeClose                 = "Close"
+	TypeSettings             = "Settings"
+	TypeUpdatePrompt         = "UpdatePrompt"
+	TypeUpdateSpeak          = "UpdateSpeak"
+	TypeInjectAgentMessage   = "InjectAgentMessage"
+	TypeFunctionCallResponse = "FunctionCallResponse"
+	TypeKeepAlive            = "KeepAlive"
+	TypeClose                = "Close"
 )
 
 // server message types

--- a/pkg/api/agent/v1/websocket/interfaces/types.go
+++ b/pkg/api/agent/v1/websocket/interfaces/types.go
@@ -5,8 +5,8 @@
 package interfacesv1
 
 import (
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /***********************************/

--- a/pkg/api/agent/v1/websocket/types.go
+++ b/pkg/api/agent/v1/websocket/types.go
@@ -5,7 +5,7 @@
 package websocketv1
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket/interfaces"
 )
 
 /*

--- a/pkg/api/analyze/v1/analyze.go
+++ b/pkg/api/analyze/v1/analyze.go
@@ -11,9 +11,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/analyze/v1/interfaces"
-	analyze "github.com/deepgram/deepgram-go-sdk/pkg/client/analyze"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/analyze/v1/interfaces"
+	analyze "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/analyze"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 type Client struct {

--- a/pkg/api/analyze/v1/interfaces/types.go
+++ b/pkg/api/analyze/v1/interfaces/types.go
@@ -5,7 +5,7 @@
 package interfaces
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /***********************************/

--- a/pkg/api/auth/v1/auth.go
+++ b/pkg/api/auth/v1/auth.go
@@ -8,9 +8,9 @@ This package contains the code for the Token APIs in the Deepgram auth API
 package auth
 
 import (
-	auth "github.com/deepgram/deepgram-go-sdk/pkg/client/auth"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	rest "github.com/deepgram/deepgram-go-sdk/pkg/client/rest" //lint:ignore
+	auth "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/auth"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	rest "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/rest" //lint:ignore
 )
 
 const (

--- a/pkg/api/auth/v1/grant-token.go
+++ b/pkg/api/auth/v1/grant-token.go
@@ -13,8 +13,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/auth/v1/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/auth/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
 )
 
 // GrantToken generates a JWT.

--- a/pkg/api/listen/v1/rest/interfaces/types.go
+++ b/pkg/api/listen/v1/rest/interfaces/types.go
@@ -5,7 +5,7 @@
 package interfacesv1
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 /***********************************/

--- a/pkg/api/listen/v1/rest/rest.go
+++ b/pkg/api/listen/v1/rest/rest.go
@@ -11,9 +11,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	rest "github.com/deepgram/deepgram-go-sdk/pkg/client/listen/v1/rest"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	rest "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen/v1/rest"
 )
 
 // Alias

--- a/pkg/api/listen/v1/websocket/callback_default.go
+++ b/pkg/api/listen/v1/websocket/callback_default.go
@@ -13,7 +13,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
 )
 
 // NewDefaultCallbackHandler creates a new DefaultCallbackHandler

--- a/pkg/api/listen/v1/websocket/callback_router.go
+++ b/pkg/api/listen/v1/websocket/callback_router.go
@@ -12,7 +12,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
 )
 
 // NewWithDefault creates a CallbackRouter with the default callback handler

--- a/pkg/api/listen/v1/websocket/chan_default.go
+++ b/pkg/api/listen/v1/websocket/chan_default.go
@@ -14,7 +14,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
 )
 
 // NewDefaultChanHandler creates a new DefaultChanHandler

--- a/pkg/api/listen/v1/websocket/chan_router.go
+++ b/pkg/api/listen/v1/websocket/chan_router.go
@@ -12,7 +12,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
 )
 
 // NewWithDefault creates a ChanRouter with the default callback handler

--- a/pkg/api/listen/v1/websocket/interfaces/constants.go
+++ b/pkg/api/listen/v1/websocket/interfaces/constants.go
@@ -5,7 +5,7 @@
 package interfacesv1
 
 import (
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
 )
 
 // These are the message types that can be received from the live API

--- a/pkg/api/listen/v1/websocket/interfaces/types.go
+++ b/pkg/api/listen/v1/websocket/interfaces/types.go
@@ -5,8 +5,8 @@
 package interfacesv1
 
 import (
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /***********************************/

--- a/pkg/api/listen/v1/websocket/types.go
+++ b/pkg/api/listen/v1/websocket/types.go
@@ -5,7 +5,7 @@
 package websocketv1
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
 )
 
 /*

--- a/pkg/api/live/v1/interfaces/constants.go
+++ b/pkg/api/live/v1/interfaces/constants.go
@@ -5,7 +5,7 @@
 package legacy
 
 import (
-	interfacesv1 "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
+	interfacesv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
 )
 
 const (

--- a/pkg/api/live/v1/interfaces/interfaces.go
+++ b/pkg/api/live/v1/interfaces/interfaces.go
@@ -12,7 +12,7 @@
 package legacy
 
 import (
-	interfacesv1 "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
+	interfacesv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
 )
 
 // Alias

--- a/pkg/api/live/v1/interfaces/types.go
+++ b/pkg/api/live/v1/interfaces/types.go
@@ -5,7 +5,7 @@
 package legacy
 
 import (
-	interfacesv1 "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
+	interfacesv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
 )
 
 /***********************************/

--- a/pkg/api/manage/v1/balances.go
+++ b/pkg/api/manage/v1/balances.go
@@ -14,8 +14,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
 )
 
 // ListBalances lists all balances for a project

--- a/pkg/api/manage/v1/interfaces/types.go
+++ b/pkg/api/manage/v1/interfaces/types.go
@@ -10,7 +10,7 @@ package interfaces
 import (
 	"time"
 
-	"github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	"github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /***********************************/

--- a/pkg/api/manage/v1/invitations.go
+++ b/pkg/api/manage/v1/invitations.go
@@ -18,8 +18,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
 )
 
 // ListInvitations lists all invitations for a project

--- a/pkg/api/manage/v1/keys.go
+++ b/pkg/api/manage/v1/keys.go
@@ -19,8 +19,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
 )
 
 // ListKeys lists all keys for a project

--- a/pkg/api/manage/v1/manage.go
+++ b/pkg/api/manage/v1/manage.go
@@ -8,9 +8,9 @@ This package contains the code for the Keys APIs in the Deepgram Manage API
 package manage
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	manage "github.com/deepgram/deepgram-go-sdk/pkg/client/manage"
-	rest "github.com/deepgram/deepgram-go-sdk/pkg/client/rest" //lint:ignore
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	manage "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage"
+	rest "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/rest" //lint:ignore
 )
 
 const (

--- a/pkg/api/manage/v1/members.go
+++ b/pkg/api/manage/v1/members.go
@@ -14,8 +14,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
 )
 
 // ListMembers lists all members for a project

--- a/pkg/api/manage/v1/models.go
+++ b/pkg/api/manage/v1/models.go
@@ -15,8 +15,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
 )
 
 // ListModels lists all models available

--- a/pkg/api/manage/v1/projects.go
+++ b/pkg/api/manage/v1/projects.go
@@ -18,8 +18,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
 )
 
 // ListProjects lists all projects for a user

--- a/pkg/api/manage/v1/scopes.go
+++ b/pkg/api/manage/v1/scopes.go
@@ -16,8 +16,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
 )
 
 // GetMemberScopes gets the scopes for a member

--- a/pkg/api/manage/v1/usage.go
+++ b/pkg/api/manage/v1/usage.go
@@ -18,8 +18,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/manage/v1/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/manage/v1/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
 )
 
 // ListRequests lists all requests for a project

--- a/pkg/api/prerecorded/v1/interfaces/types.go
+++ b/pkg/api/prerecorded/v1/interfaces/types.go
@@ -5,7 +5,7 @@
 package interfacesv1
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 /***********************************/

--- a/pkg/api/speak/v1/rest/interfaces/types.go
+++ b/pkg/api/speak/v1/rest/interfaces/types.go
@@ -5,7 +5,7 @@
 package interfacesv1
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /***********************************/

--- a/pkg/api/speak/v1/rest/speak.go
+++ b/pkg/api/speak/v1/rest/speak.go
@@ -13,9 +13,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/rest/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	speak "github.com/deepgram/deepgram-go-sdk/pkg/client/speak/v1/rest"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/rest/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	speak "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak/v1/rest"
 )
 
 type Client struct {

--- a/pkg/api/speak/v1/speak.go
+++ b/pkg/api/speak/v1/speak.go
@@ -12,8 +12,8 @@
 package legacy
 
 import (
-	speakv1 "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/rest"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/speak"
+	speakv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/rest"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak"
 )
 
 const (

--- a/pkg/api/speak/v1/websocket/callback_default.go
+++ b/pkg/api/speak/v1/websocket/callback_default.go
@@ -13,7 +13,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
 )
 
 // NewDefaultCallbackHandler creates a new DefaultCallbackHandler

--- a/pkg/api/speak/v1/websocket/callback_router.go
+++ b/pkg/api/speak/v1/websocket/callback_router.go
@@ -12,7 +12,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
 )
 
 // NewWithDefault creates a CallbackRouter with the default callback handler

--- a/pkg/api/speak/v1/websocket/chan_default.go
+++ b/pkg/api/speak/v1/websocket/chan_default.go
@@ -14,7 +14,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
 )
 
 // NewDefaultChanHandler creates a new DefaultChanHandler

--- a/pkg/api/speak/v1/websocket/chan_router.go
+++ b/pkg/api/speak/v1/websocket/chan_router.go
@@ -13,7 +13,7 @@ import (
 	prettyjson "github.com/hokaccha/go-prettyjson"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
 )
 
 // NewWithDefault creates a ChanRouter with the default callback handler

--- a/pkg/api/speak/v1/websocket/interfaces/constants.go
+++ b/pkg/api/speak/v1/websocket/interfaces/constants.go
@@ -5,7 +5,7 @@
 package interfacesv1
 
 import (
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
 )
 
 // These are the message types that can be received from the live API

--- a/pkg/api/speak/v1/websocket/interfaces/types.go
+++ b/pkg/api/speak/v1/websocket/interfaces/types.go
@@ -5,8 +5,8 @@
 package interfacesv1
 
 import (
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /***********************************/

--- a/pkg/api/speak/v1/websocket/types.go
+++ b/pkg/api/speak/v1/websocket/types.go
@@ -5,7 +5,7 @@
 package websocketv1
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
 )
 
 /*

--- a/pkg/api/version/analyze-version.go
+++ b/pkg/api/version/analyze-version.go
@@ -7,7 +7,7 @@ package version
 import (
 	"context"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /*

--- a/pkg/api/version/live-version.go
+++ b/pkg/api/version/live-version.go
@@ -7,7 +7,7 @@ package version
 import (
 	"context"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 const (

--- a/pkg/api/version/prerecorded-version.go
+++ b/pkg/api/version/prerecorded-version.go
@@ -7,7 +7,7 @@ package version
 import (
 	"context"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /*

--- a/pkg/api/version/speak-version.go
+++ b/pkg/api/version/speak-version.go
@@ -7,7 +7,7 @@ package version
 import (
 	"context"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /*

--- a/pkg/api/version/speakstream-version.go
+++ b/pkg/api/version/speakstream-version.go
@@ -7,7 +7,7 @@ package version
 import (
 	"context"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 const (

--- a/pkg/api/version/version.go
+++ b/pkg/api/version/version.go
@@ -14,8 +14,8 @@ import (
 	"github.com/gorilla/schema"
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // getAPIURL constructs the URL for API requests and handles versioning, path resolution,

--- a/pkg/client/agent/client.go
+++ b/pkg/client/agent/client.go
@@ -10,9 +10,9 @@ package agent
 import (
 	"context"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket/interfaces"
-	listenv1ws "github.com/deepgram/deepgram-go-sdk/pkg/client/agent/v1/websocket"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket/interfaces"
+	listenv1ws "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/agent/v1/websocket"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /***********************************/

--- a/pkg/client/agent/init.go
+++ b/pkg/client/agent/init.go
@@ -5,7 +5,7 @@
 package agent
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/agent/v1/websocket/client_channel.go
+++ b/pkg/client/agent/v1/websocket/client_channel.go
@@ -17,9 +17,9 @@ import (
 	"github.com/dvonthenen/websocket"
 	klog "k8s.io/klog/v2"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // Connect performs a websocket connection with "DefaultConnectRetry" number of retries.

--- a/pkg/client/agent/v1/websocket/new_using_chan.go
+++ b/pkg/client/agent/v1/websocket/new_using_chan.go
@@ -10,11 +10,11 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	websocketv1api "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket"
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket/interfaces"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	clientinterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	websocketv1api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	clientinterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /*

--- a/pkg/client/agent/v1/websocket/types.go
+++ b/pkg/client/agent/v1/websocket/types.go
@@ -7,10 +7,10 @@ package websocketv1
 import (
 	"context"
 
-	msginterface "github.com/deepgram/deepgram-go-sdk/pkg/api/agent/v1/websocket/interfaces"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	msginterface "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/agent/v1/websocket/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 // client messages

--- a/pkg/client/analyze/client.go
+++ b/pkg/client/analyze/client.go
@@ -6,8 +6,8 @@
 package analyze
 
 import (
-	analyzev1 "github.com/deepgram/deepgram-go-sdk/pkg/client/analyze/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	analyzev1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/analyze/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 const (

--- a/pkg/client/analyze/init.go
+++ b/pkg/client/analyze/init.go
@@ -5,7 +5,7 @@
 package analyze
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/analyze/v1/client.go
+++ b/pkg/client/analyze/v1/client.go
@@ -18,9 +18,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 type textSource struct {

--- a/pkg/client/analyze/v1/types.go
+++ b/pkg/client/analyze/v1/types.go
@@ -5,7 +5,7 @@
 package analyzev1
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // Client implements helper functionality for Prerecorded API

--- a/pkg/client/auth/client.go
+++ b/pkg/client/auth/client.go
@@ -6,8 +6,8 @@
 package auth
 
 import (
-	authv1 "github.com/deepgram/deepgram-go-sdk/pkg/client/auth/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	authv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/auth/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 const (

--- a/pkg/client/auth/init.go
+++ b/pkg/client/auth/init.go
@@ -6,7 +6,7 @@
 package auth
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/auth/v1/client.go
+++ b/pkg/client/auth/v1/client.go
@@ -11,9 +11,9 @@ import (
 
 	"k8s.io/klog/v2"
 
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 const (

--- a/pkg/client/auth/v1/types.go
+++ b/pkg/client/auth/v1/types.go
@@ -6,7 +6,7 @@
 package authv1
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // Client is the client for the Deepgram Auth API

--- a/pkg/client/common/v1/interfaces/interfaces.go
+++ b/pkg/client/common/v1/interfaces/interfaces.go
@@ -5,7 +5,7 @@
 // This package defines interfaces for the live API
 package interfacesv1
 
-import "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+import "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 
 /*
 Shared Structs

--- a/pkg/client/common/v1/rest.go
+++ b/pkg/client/common/v1/rest.go
@@ -15,8 +15,8 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
-	restv1 "github.com/deepgram/deepgram-go-sdk/pkg/client/rest/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
+	restv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/rest/v1"
 )
 
 func NewREST(apiKey string, options *interfaces.ClientOptions) *RESTClient {

--- a/pkg/client/common/v1/types.go
+++ b/pkg/client/common/v1/types.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/dvonthenen/websocket"
 
-	commonv1interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	clientinterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	restv1 "github.com/deepgram/deepgram-go-sdk/pkg/client/rest/v1"
+	commonv1interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	clientinterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	restv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/rest/v1"
 )
 
 const (

--- a/pkg/client/common/v1/websocket.go
+++ b/pkg/client/common/v1/websocket.go
@@ -18,8 +18,8 @@ import (
 	"github.com/dvonthenen/websocket"
 	klog "k8s.io/klog/v2"
 
-	commonv1interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	clientinterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	commonv1interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	clientinterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 // gocritic:ignore

--- a/pkg/client/interfaces/interfaces.go
+++ b/pkg/client/interfaces/interfaces.go
@@ -5,7 +5,7 @@
 package interfaces
 
 import (
-	interfacesv1 "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	interfacesv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 const (

--- a/pkg/client/interfaces/utils.go
+++ b/pkg/client/interfaces/utils.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"net/http"
 
-	interfacesv1 "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	interfacesv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 // DgAgent is the agent version

--- a/pkg/client/listen/client.go
+++ b/pkg/client/listen/client.go
@@ -10,10 +10,10 @@ package listen
 import (
 	"context"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	listenv1rest "github.com/deepgram/deepgram-go-sdk/pkg/client/listen/v1/rest"
-	listenv1ws "github.com/deepgram/deepgram-go-sdk/pkg/client/listen/v1/websocket"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	listenv1rest "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen/v1/rest"
+	listenv1ws "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen/v1/websocket"
 )
 
 /***********************************/

--- a/pkg/client/listen/init.go
+++ b/pkg/client/listen/init.go
@@ -5,7 +5,7 @@
 package listen
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/listen/v1/rest/client.go
+++ b/pkg/client/listen/v1/rest/client.go
@@ -20,9 +20,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 type urlSource struct {

--- a/pkg/client/listen/v1/rest/types.go
+++ b/pkg/client/listen/v1/rest/types.go
@@ -5,7 +5,7 @@
 package restv1
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // RESTClient implements helper functionality for Prerecorded API

--- a/pkg/client/listen/v1/websocket/client_callback.go
+++ b/pkg/client/listen/v1/websocket/client_callback.go
@@ -18,9 +18,9 @@ import (
 	"github.com/dvonthenen/websocket"
 	klog "k8s.io/klog/v2"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // Connect performs a websocket connection with "DefaultConnectRetry" number of retries.

--- a/pkg/client/listen/v1/websocket/client_channel.go
+++ b/pkg/client/listen/v1/websocket/client_channel.go
@@ -18,9 +18,9 @@ import (
 	"github.com/dvonthenen/websocket"
 	klog "k8s.io/klog/v2"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // Connect performs a websocket connection with "DefaultConnectRetry" number of retries.

--- a/pkg/client/listen/v1/websocket/new_using_callbacks.go
+++ b/pkg/client/listen/v1/websocket/new_using_callbacks.go
@@ -10,11 +10,11 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	websocketv1api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket"
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	clientinterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	websocketv1api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	clientinterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /*

--- a/pkg/client/listen/v1/websocket/new_using_chan.go
+++ b/pkg/client/listen/v1/websocket/new_using_chan.go
@@ -10,11 +10,11 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	websocketv1api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket"
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	clientinterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	websocketv1api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	clientinterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /*

--- a/pkg/client/listen/v1/websocket/types.go
+++ b/pkg/client/listen/v1/websocket/types.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
-	msginterface "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	msginterface "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 // internal structs

--- a/pkg/client/live/deprecated.go
+++ b/pkg/client/live/deprecated.go
@@ -14,9 +14,9 @@ package live
 import (
 	"context"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/live/v1/interfaces" //lint:ignore
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	listenv1ws "github.com/deepgram/deepgram-go-sdk/pkg/client/listen/v1/websocket"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/live/v1/interfaces" //lint:ignore
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	listenv1ws "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen/v1/websocket"
 )
 
 const (

--- a/pkg/client/live/init.go
+++ b/pkg/client/live/init.go
@@ -12,7 +12,7 @@
 package live
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/manage/client.go
+++ b/pkg/client/manage/client.go
@@ -6,8 +6,8 @@
 package manage
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
-	managev1 "github.com/deepgram/deepgram-go-sdk/pkg/client/manage/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
+	managev1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/manage/v1"
 )
 
 const (

--- a/pkg/client/manage/init.go
+++ b/pkg/client/manage/init.go
@@ -6,7 +6,7 @@
 package manage
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/manage/v1/client.go
+++ b/pkg/client/manage/v1/client.go
@@ -11,9 +11,9 @@ import (
 
 	"k8s.io/klog/v2"
 
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 const (

--- a/pkg/client/manage/v1/types.go
+++ b/pkg/client/manage/v1/types.go
@@ -6,7 +6,7 @@
 package managev1
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // Client is the client for the Deepgram Manage API

--- a/pkg/client/prerecorded/deprecated.go
+++ b/pkg/client/prerecorded/deprecated.go
@@ -12,8 +12,8 @@
 package prerecorded
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
-	listenv1rest "github.com/deepgram/deepgram-go-sdk/pkg/client/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
+	listenv1rest "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen/v1/rest"
 )
 
 /***********************************/

--- a/pkg/client/prerecorded/init.go
+++ b/pkg/client/prerecorded/init.go
@@ -12,7 +12,7 @@
 package prerecorded
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/rest/client.go
+++ b/pkg/client/rest/client.go
@@ -12,8 +12,8 @@
 package rest
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
-	restv1 "github.com/deepgram/deepgram-go-sdk/pkg/client/rest/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
+	restv1 "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/rest/v1"
 )
 
 const (

--- a/pkg/client/rest/init.go
+++ b/pkg/client/rest/init.go
@@ -12,7 +12,7 @@
 package rest
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/rest/v1/debug.go
+++ b/pkg/client/rest/v1/debug.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/deepgram/deepgram-go-sdk/pkg/client/rest/v1/debug"
+	"github.com/deepgram/deepgram-go-sdk/v2/pkg/client/rest/v1/debug"
 )
 
 var (

--- a/pkg/client/rest/v1/http.go
+++ b/pkg/client/rest/v1/http.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"time"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 // New allocated a Simple HTTP client

--- a/pkg/client/rest/v1/init.go
+++ b/pkg/client/rest/v1/init.go
@@ -5,7 +5,7 @@
 package restv1
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/rest/v1/rest.go
+++ b/pkg/client/rest/v1/rest.go
@@ -18,7 +18,7 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 const (

--- a/pkg/client/rest/v1/types.go
+++ b/pkg/client/rest/v1/types.go
@@ -7,7 +7,7 @@ package restv1
 import (
 	"net/http"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 // HTTPClient which extends HTTP client

--- a/pkg/client/speak/client.go
+++ b/pkg/client/speak/client.go
@@ -10,10 +10,10 @@ package speak
 import (
 	"context"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
-	speakv1rest "github.com/deepgram/deepgram-go-sdk/pkg/client/speak/v1/rest"
-	speakv1ws "github.com/deepgram/deepgram-go-sdk/pkg/client/speak/v1/websocket"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
+	speakv1rest "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak/v1/rest"
+	speakv1ws "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak/v1/websocket"
 )
 
 /***********************************/

--- a/pkg/client/speak/deprecated.go
+++ b/pkg/client/speak/deprecated.go
@@ -5,8 +5,8 @@
 package speak
 
 import (
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
-	speakv1rest "github.com/deepgram/deepgram-go-sdk/pkg/client/speak/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
+	speakv1rest "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/speak/v1/rest"
 )
 
 /***********************************/

--- a/pkg/client/speak/init.go
+++ b/pkg/client/speak/init.go
@@ -5,7 +5,7 @@
 package speak
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/common"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/common"
 )
 
 // please see pkg/common/init.go for more information

--- a/pkg/client/speak/v1/rest/client.go
+++ b/pkg/client/speak/v1/rest/client.go
@@ -14,9 +14,9 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 type textSource struct {

--- a/pkg/client/speak/v1/rest/types.go
+++ b/pkg/client/speak/v1/rest/types.go
@@ -5,7 +5,7 @@
 package restv1
 
 import (
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // Client implements helper functionality for Prerecorded API

--- a/pkg/client/speak/v1/websocket/client_callback.go
+++ b/pkg/client/speak/v1/websocket/client_callback.go
@@ -17,9 +17,9 @@ import (
 	"github.com/dvonthenen/websocket"
 	klog "k8s.io/klog/v2"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // Connect performs a websocket connection with "DefaultConnectRetry" number of retries.

--- a/pkg/client/speak/v1/websocket/client_channel.go
+++ b/pkg/client/speak/v1/websocket/client_channel.go
@@ -17,9 +17,9 @@ import (
 	"github.com/dvonthenen/websocket"
 	klog "k8s.io/klog/v2"
 
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	version "github.com/deepgram/deepgram-go-sdk/pkg/api/version"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	version "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/version"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
 )
 
 // Connect performs a websocket connection with "DefaultConnectRetry" number of retries.

--- a/pkg/client/speak/v1/websocket/new_using_callbacks.go
+++ b/pkg/client/speak/v1/websocket/new_using_callbacks.go
@@ -10,11 +10,11 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	websocketv1api "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket"
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	clientinterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	websocketv1api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	clientinterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 /*

--- a/pkg/client/speak/v1/websocket/new_using_chan.go
+++ b/pkg/client/speak/v1/websocket/new_using_chan.go
@@ -9,11 +9,11 @@ import (
 
 	klog "k8s.io/klog/v2"
 
-	websocketv1api "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket"
-	msginterfaces "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	clientinterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
+	websocketv1api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket"
+	msginterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	clientinterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
 )
 
 /*

--- a/pkg/client/speak/v1/websocket/types.go
+++ b/pkg/client/speak/v1/websocket/types.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
-	msginterface "github.com/deepgram/deepgram-go-sdk/pkg/api/speak/v1/websocket/interfaces"
-	common "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1"
-	commoninterfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/common/v1/interfaces"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces/v1"
+	msginterface "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/speak/v1/websocket/interfaces"
+	common "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1"
+	commoninterfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/common/v1/interfaces"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces/v1"
 )
 
 // external structs

--- a/tests/daily_test/prerecorded_test.go
+++ b/tests/daily_test/prerecorded_test.go
@@ -15,11 +15,11 @@ import (
 	"strings"
 	"testing"
 
-	prerecorded "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen/v1/rest"
+	prerecorded "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen/v1/rest"
 
-	utils "github.com/deepgram/deepgram-go-sdk/tests/utils"
+	utils "github.com/deepgram/deepgram-go-sdk/v2/tests/utils"
 )
 
 const (

--- a/tests/edge_cases/cancel/main.go
+++ b/tests/edge_cases/cancel/main.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"os"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 func main() {

--- a/tests/edge_cases/failed_retry/main.go
+++ b/tests/edge_cases/failed_retry/main.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"os"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 func main() {

--- a/tests/edge_cases/keepalive/main.go
+++ b/tests/edge_cases/keepalive/main.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"os"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 func main() {

--- a/tests/edge_cases/reconnect_client/main.go
+++ b/tests/edge_cases/reconnect_client/main.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"time"
 
-	api "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/websocket/interfaces"
-	microphone "github.com/deepgram/deepgram-go-sdk/pkg/audio/microphone"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	api "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/websocket/interfaces"
+	microphone "github.com/deepgram/deepgram-go-sdk/v2/pkg/audio/microphone"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 // Implement your own callback

--- a/tests/edge_cases/timeout/main.go
+++ b/tests/edge_cases/timeout/main.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"os"
 
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen"
 )
 
 func main() {

--- a/tests/unit_test/prerecorded_test.go
+++ b/tests/unit_test/prerecorded_test.go
@@ -19,11 +19,11 @@ import (
 	"github.com/gorilla/schema"
 	"github.com/jarcoal/httpmock"
 
-	prerecorded "github.com/deepgram/deepgram-go-sdk/pkg/api/listen/v1/rest"
-	interfaces "github.com/deepgram/deepgram-go-sdk/pkg/client/interfaces"
-	client "github.com/deepgram/deepgram-go-sdk/pkg/client/listen/v1/rest"
+	prerecorded "github.com/deepgram/deepgram-go-sdk/v2/pkg/api/listen/v1/rest"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v2/pkg/client/listen/v1/rest"
 
-	utils "github.com/deepgram/deepgram-go-sdk/tests/utils"
+	utils "github.com/deepgram/deepgram-go-sdk/v2/tests/utils"
 )
 
 const (


### PR DESCRIPTION
Go will not allow us to publish a major version change without updating this, apparently.