### PR TITLE
fix: respect Proxy configuration in REST client options

### DIFF
--- a/pkg/client/rest/v1/http.go
+++ b/pkg/client/rest/v1/http.go
@@ -19,6 +19,7 @@ func NewHTTPClient(options *interfaces.ClientOptions) *HTTPClient {
 	/* #nosec G402 */
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: options.SkipServerAuth},
+		Proxy:           options.Proxy,
 	}
 
 	c := HTTPClient{


### PR DESCRIPTION
Previously, the REST client ignored the Proxy field in ClientOptions, forcing direct connections even when a proxy was configured.

## Proposed changes
This PR fixes a bug where the REST client (used for pre-recorded audio, management API, etc.) completely ignored the Proxy configuration provided in ClientOptions.

Previously, NewHTTPClient in pkg/client/rest/v1/http.go initialized http.Transport without assigning the Proxy field, forcing direct connections even when a proxy (SOCKS5/HTTP) was explicitly configured.

This change adds Proxy: options.Proxy to the transport initialization, ensuring that the REST client respects the user's network configuration. This aligns the REST client behavior with the existing WebSocket client implementation.

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
The fix is a one-line addition to pkg/client/rest/v1/http.go. Implementation now matches how proxies are handled in pkg/client/common/v1/websocket.go. Verified manually by making requests through a SOCKS5 proxy.

