### PR TITLE
feat: add entity support for streaming transcription

### DIFF
--- a/pkg/api/listen/v1/websocket/interfaces/types.go
+++ b/pkg/api/listen/v1/websocket/interfaces/types.go
@@ -52,6 +52,15 @@ type Alternative struct {
 	Languages  []string `json:"languages,omitempty"`
 }
 
+// Entity is a named entity recognized in the transcript
+type Entity struct {
+	Label      string  `json:"label,omitempty"`
+	Value      string  `json:"value,omitempty"`
+	Confidence float64 `json:"confidence,omitempty"`
+	StartWord  float64 `json:"start_word,omitempty"`
+	EndWord    float64 `json:"end_word,omitempty"`
+}
+
 // Channel is a single channel in a transcript
 type Channel struct {
 	Alternatives []Alternative `json:"alternatives,omitempty"`
@@ -94,6 +103,7 @@ type MessageResponse struct {
 	SpeechFinal  bool     `json:"speech_final,omitempty"`
 	Start        float64  `json:"start,omitempty"`
 	Type         string   `json:"type,omitempty"`
+	Entities     []Entity `json:"entities,omitempty"`
 }
 
 // MetadataResponse is the response from a live transcription

--- a/pkg/client/interfaces/v1/types-stream.go
+++ b/pkg/client/interfaces/v1/types-stream.go
@@ -19,6 +19,7 @@ type LiveTranscriptionOptions struct {
 	Diarize         bool     `json:"diarize,omitempty" schema:"diarize,omitempty"`
 	DiarizeVersion  string   `json:"diarize_version,omitempty" schema:"diarize_version,omitempty"`
 	Dictation       bool     `json:"dictation,omitempty" schema:"dictation,omitempty"` // Option to format spoken punctuated commands, must be enabled with punctuate parameter to true. Eg: "i went to the store comma new paragraph then i went home period" --> "i went to the store, <\n> then i went home."
+	DetectEntities  bool     `json:"detect_entities,omitempty" schema:"detect_entities,omitempty"`
 	Encoding        string   `json:"encoding,omitempty" schema:"encoding,omitempty"`
 	Endpointing     string   `json:"endpointing,omitempty" schema:"endpointing,omitempty"`
 	Extra           []string `json:"extra,omitempty" schema:"extra,omitempty"`


### PR DESCRIPTION
Add DetectEntities option to LiveTranscriptionOptions and Entities field to MessageResponse for WebSocket streaming transcription.

This enables users to receive named entity recognition (NER) data when using the Deepgram streaming API with detect_entities=true.

Entities are returned at the top-level of the MessageResponse, matching the Deepgram API response format.

## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->


## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

