### PR TITLE
chore: add Context7 MCP server configuration [no-ci]

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/deepgram/deepgram-go-sdk",
+  "public_key": "pk_hu7APZeIXQ14hNyaCBm0A"
+}


### PR DESCRIPTION
Adds Context7 configuration file to enable documentation lookups for the Go SDK.

This is a non-release change (marked [no-ci] to prevent release-please from triggering).