### PR TITLE
feat: improve 5 lowest-scoring skill definitions

### DIFF
--- a/.agents/skills/deepgram-go-audio-intelligence/SKILL.md
+++ b/.agents/skills/deepgram-go-audio-intelligence/SKILL.md
@@ -1,21 +1,11 @@
 ---
 name: deepgram-go-audio-intelligence
-description: Use when writing or reviewing Go code in this repo that applies summaries, topics, intents, sentiment, language detection, diarization, redaction, or entity extraction to audio inputs through Listen v1 REST. Route plain transcription to deepgram-go-speech-to-text and plain-text Read requests to deepgram-go-text-intelligence.
+description: "Use when writing or reviewing Go code in this repo that applies summaries, topics, intents, sentiment, language detection, diarization, redaction, or entity extraction to audio inputs through Listen v1 REST. Route plain transcription to deepgram-go-speech-to-text and plain-text Read requests to deepgram-go-text-intelligence."
 ---
 
 # Using Deepgram Audio Intelligence from the Go SDK
 
-## When to use this product
-
-Use this skill for `/v1/listen` REST requests that combine transcription with analytics overlays.
-
-- summaries
-- topics
-- intents
-- sentiments
-- entity extraction
-- language detection
-- diarization and redaction where supported
+Use this skill for `/v1/listen` REST requests that combine transcription with analytics overlays: summaries, topics, intents, sentiments, entity extraction, language detection, diarization, and redaction.
 
 Use a different skill when:
 
@@ -23,8 +13,6 @@ Use a different skill when:
 - your input is already text (`deepgram-go-text-intelligence`)
 
 ## Authentication
-
-Set `DEEPGRAM_API_KEY` before creating the listen REST client.
 
 ```bash
 export DEEPGRAM_API_KEY="your_api_key"
@@ -80,67 +68,36 @@ func run() error {
 
 ## Key parameters
 
-- analytics live on `interfaces.PreRecordedTranscriptionOptions`
-	- `Summarize` (for example, `"v2"`)
-	- `Topics`
-	- `Intents`
-	- `Sentiment`
-  - `DetectLanguage`
-  - `DetectEntities`
-  - `Diarize`
-  - `Redact`
-- response payloads are in `pkg/api/listen/v1/rest/interfaces/types.go`
-  - `Sentiments`
-  - `Topics`
-  - `Intents`
-  - `Entities`
-  - `SummaryV2`
-- this SDK is REST-first for audio intelligence; the live WS option struct does not expose the same analytics surface
+Analytics flags on `interfaces.PreRecordedTranscriptionOptions`:
+
+| Flag | Type | Notes |
+|------|------|-------|
+| `Summarize` | `string` | e.g. `"v2"` |
+| `Topics` | `bool` | |
+| `Intents` | `bool` | |
+| `Sentiment` | `bool` | |
+| `DetectLanguage` | `bool` | |
+| `DetectEntities` | `bool` | |
+| `Diarize` | `bool` | |
+| `Redact` | `[]string` | |
+
+Response payloads in `pkg/api/listen/v1/rest/interfaces/types.go`: `Sentiments`, `Topics`, `Intents`, `Entities`, `SummaryV2`.
 
 ## API reference (layered)
 
-1. In-repo reference
-   - `README.md`
-   - `docs.go`
-   - `pkg/client/listen/v1/rest/client.go`
-   - `pkg/client/interfaces/v1/types-prerecorded.go`
-   - `pkg/client/interfaces/v1/types-stream.go`
-   - `pkg/api/listen/v1/rest/interfaces/types.go`
-2. OpenAPI
-   - `https://developers.deepgram.com/openapi.yaml`
-3. AsyncAPI
-   - `https://developers.deepgram.com/asyncapi.yaml`
-4. Context7
-   - `/llmstxt/developers_deepgram_llms_txt`
-5. Product docs
-   - `https://developers.deepgram.com/docs/stt-intelligence-feature-overview`
-   - `https://developers.deepgram.com/docs/summarization`
-   - `https://developers.deepgram.com/docs/topic-detection`
-   - `https://developers.deepgram.com/docs/intent-recognition`
-   - `https://developers.deepgram.com/docs/sentiment-analysis`
-   - `https://developers.deepgram.com/docs/language-detection`
-   - `https://developers.deepgram.com/docs/redaction`
-   - `https://developers.deepgram.com/docs/diarization`
+1. In-repo: `pkg/client/listen/v1/rest/client.go`, `pkg/client/interfaces/v1/types-prerecorded.go`, `pkg/api/listen/v1/rest/interfaces/types.go`
+2. OpenAPI: `https://developers.deepgram.com/openapi.yaml`
+3. Product docs: `https://developers.deepgram.com/docs/stt-intelligence-feature-overview`, `https://developers.deepgram.com/docs/summarization`, `https://developers.deepgram.com/docs/sentiment-analysis`
 
 ## Gotchas
 
-1. In this SDK snapshot, audio intelligence is effectively a prerecorded REST feature set.
-2. `LiveTranscriptionOptions` does not expose the same summarize/topic/intent/sentiment/entity surface.
-3. REST helpers live on `pkg/api/listen/v1/rest`; start from `api.New(listen.NewRESTWithDefaults())`, then layer analytics flags onto `PreRecordedTranscriptionOptions`.
+1. Audio intelligence is a **prerecorded REST** feature set only; `LiveTranscriptionOptions` does not expose the same analytics surface.
+2. Build via `api.New(listen.NewRESTWithDefaults())`, then layer analytics flags onto `PreRecordedTranscriptionOptions`.
+3. Do not send raw text here; text analysis belongs in `deepgram-go-text-intelligence`.
 
-## Example files in this repo
+## Example files
 
 - `examples/speech-to-text/rest/summary/main.go`
 - `examples/speech-to-text/rest/sentiment/main.go`
 - `examples/speech-to-text/rest/topic/main.go`
 - `examples/speech-to-text/rest/intent/main.go`
-
-## Central product skills
-
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).

--- a/.agents/skills/deepgram-go-conversational-stt/SKILL.md
+++ b/.agents/skills/deepgram-go-conversational-stt/SKILL.md
@@ -1,88 +1,98 @@
 ---
 name: deepgram-go-conversational-stt
-description: Use when planning or reviewing Go SDK work for Deepgram conversational STT / Flux v2. This repo does not currently ship a first-class v2 listen client, so route supported v1 transcription to deepgram-go-speech-to-text and document raw WebSocket fallback honestly when v2 is requested.
+description: "Use when planning, prototyping, or reviewing Go SDK work for Deepgram conversational speech-to-text / Flux v2 real-time streaming transcription. Guides raw WebSocket integration against the shared client plumbing, configures host and version overrides, and routes supported v1 listen transcription to deepgram-go-speech-to-text."
 ---
 
 # Using Deepgram Conversational STT from the Go SDK
 
-## When to use this product
+Use when someone asks for Flux, conversational STT v2, or real-time streaming transcription v2 in the Go SDK.
 
-Use this skill when someone asks for Flux or conversational STT v2 in the Go SDK.
-
-Current repo status: this SDK snapshot does **not** implement a first-class `listen/v2` client.
+**Current status:** this SDK does **not** ship a first-class `listen/v2` client. The guidance below covers the raw WebSocket fallback.
 
 Use a different skill when:
 
-- v1 Listen is acceptable (`deepgram-go-speech-to-text`)
+- v1 Listen REST or WebSocket is acceptable (`deepgram-go-speech-to-text`)
 - voice-agent runtime is the real target (`deepgram-go-voice-agent`)
 
 ## Authentication
-
-If you hand-roll a raw WebSocket client, it still uses the same Deepgram credentials.
 
 ```bash
 export DEEPGRAM_API_KEY="your_api_key"
 ```
 
-## Quick start
+## Raw v2 WebSocket integration
 
-There is no supported `pkg/client/listen/v2` constructor in this repo today.
+No `pkg/client/listen/v2` constructor exists. To prototype v2, use the shared WebSocket plumbing with host/version overrides:
 
-What you can do instead:
+```go
+package main
 
-- use `deepgram-go-speech-to-text` for supported `listen` v1 flows
-- if you must prototype v2, start from the low-level shared WebSocket plumbing and path/version hooks already in the repo:
-  - `pkg/client/common/v1/websocket.go`
-  - `pkg/client/interfaces/v1/types-client.go`
-  - `pkg/api/version/live-version.go`
-  - `pkg/api/version/constants.go`
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
 
-Treat that path as a manual integration, not an SDK-supported product surface.
+	common "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/common/v1"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces"
+)
 
-## Key parameters
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
 
-- unsupported in current public package layout
-  - no `pkg/client/listen/v2`
-  - no `pkg/api/listen/v2`
-- possible raw integration hooks
-  - client host/version/path overrides from the shared client options
-  - shared WS lifecycle and reconnect logic in `pkg/client/common/v1/websocket.go`
+func run() error {
+	ctx := context.Background()
+
+	// 1. Build client options with v2 path override
+	opts := interfaces.ClientOptions{
+		APIKey: os.Getenv("DEEPGRAM_API_KEY"),
+		Host:   "api.deepgram.com",
+		Path:   "/v2/listen", // override default v1 path
+	}
+
+	// 2. Create a raw WS connection using shared plumbing
+	ws := common.New(ctx, "", &opts)
+
+	// 3. Connect and validate
+	if ok := ws.Connect(); !ok {
+		return fmt.Errorf("v2 WebSocket connect failed — verify API key and endpoint")
+	}
+	defer ws.Stop()
+
+	// 4. Start read/write pumps
+	ws.Start()
+
+	// 5. Stream PCM audio frames
+	//    for chunk := range audioSource { ws.WriteBinary(chunk) }
+
+	// 6. Finalize and shut down
+	//    ws.Finalize()
+	return nil
+}
+```
+
+**Treat this as a manual integration**, not an SDK-supported surface. Do not invent `listen/v2` package paths or constructors.
+
+## Key files for raw integration
+
+| Purpose | File |
+|---------|------|
+| Shared WS lifecycle and reconnect | `pkg/client/common/v1/websocket.go` |
+| Client option types (host, path overrides) | `pkg/client/interfaces/v1/types-client.go` |
+| Version and path constants | `pkg/api/version/live-version.go`, `pkg/api/version/constants.go` |
 
 ## API reference (layered)
 
-1. In-repo reference
-   - `README.md`
-   - `docs.go`
-   - `pkg/client/common/v1/websocket.go`
-   - `pkg/client/interfaces/v1/types-client.go`
-   - `pkg/api/version/live-version.go`
-   - `pkg/api/version/constants.go`
-2. OpenAPI
-   - `https://developers.deepgram.com/openapi.yaml`
-3. AsyncAPI
-   - `https://developers.deepgram.com/asyncapi.yaml`
-4. Context7
-   - `/llmstxt/developers_deepgram_llms_txt`
-5. Product docs
-   - `https://developers.deepgram.com/docs/conversational-speech-recognition`
+1. In-repo: `pkg/client/common/v1/websocket.go`, `pkg/client/interfaces/v1/types-client.go`, `pkg/api/version/live-version.go`
+2. OpenAPI: `https://developers.deepgram.com/openapi.yaml`
+3. AsyncAPI: `https://developers.deepgram.com/asyncapi.yaml`
+4. Product docs: `https://developers.deepgram.com/docs/conversational-speech-recognition`
 
 ## Gotchas
 
-1. Be explicit: conversational STT v2 is not yet implemented as a first-class Go SDK client here.
-2. Do not invent `listen/v2` package paths, constructors, or examples.
-3. If a task requires production-ready Flux support, point to raw API usage or another SDK until this repo adds first-class coverage.
-
-## Example files in this repo
-
-- No dedicated conversational STT v2 examples exist in this repo.
-- For shared WS patterns, inspect `tests/edge_cases/keepalive/main.go` and `tests/edge_cases/reconnect_client/main.go`.
-
-## Central product skills
-
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).
+1. Conversational STT v2 is **not** a first-class Go SDK client here. Do not invent `listen/v2` constructors.
+2. If production-ready Flux support is required, point to raw API usage or another SDK.
+3. For WS reconnect and keepalive patterns, see `tests/edge_cases/keepalive/main.go` and `tests/edge_cases/reconnect_client/main.go`.

--- a/.agents/skills/deepgram-go-conversational-stt/SKILL.md
+++ b/.agents/skills/deepgram-go-conversational-stt/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: deepgram-go-conversational-stt
-description: "Use when planning, prototyping, or reviewing Go SDK work for Deepgram conversational speech-to-text / Flux v2 real-time streaming transcription. Guides raw WebSocket integration against the shared client plumbing, configures host and version overrides, and routes supported v1 listen transcription to deepgram-go-speech-to-text."
+description: "Use when writing or reviewing Go code in this repo that streams conversational, turn-based audio through the Deepgram Flux (v2/listen) WebSocket API. Covers the first-class `pkg/client/listen/v2` client (callback and channel variants), `FluxTranscriptionOptions`, turn lifecycle events, and mid-session reconfiguration. Route classic v1 listen transcription to deepgram-go-speech-to-text, text generation to deepgram-go-text-to-speech, and voice-agent runtime work to deepgram-go-voice-agent."
 ---
 
-# Using Deepgram Conversational STT from the Go SDK
+# Using Deepgram Conversational STT (Flux) from the Go SDK
 
-Use when someone asks for Flux, conversational STT v2, or real-time streaming transcription v2 in the Go SDK.
-
-**Current status:** this SDK does **not** ship a first-class `listen/v2` client. The guidance below covers the raw WebSocket fallback.
+Use this skill for `pkg/client/listen/v2` work: real-time conversational transcription against `wss://api.deepgram.com/v2/listen` using Deepgram's Flux turn-based audio API. Available since SDK v3.6.0.
 
 Use a different skill when:
 
-- v1 Listen REST or WebSocket is acceptable (`deepgram-go-speech-to-text`)
+- v1 Listen REST or WebSocket is the target (`deepgram-go-speech-to-text`)
 - voice-agent runtime is the real target (`deepgram-go-voice-agent`)
+- TTS output is needed (`deepgram-go-text-to-speech`)
 
 ## Authentication
 
@@ -20,9 +19,7 @@ Use a different skill when:
 export DEEPGRAM_API_KEY="your_api_key"
 ```
 
-## Raw v2 WebSocket integration
-
-No `pkg/client/listen/v2` constructor exists. To prototype v2, use the shared WebSocket plumbing with host/version overrides:
+## Quick start -- callback client
 
 ```go
 package main
@@ -33,9 +30,27 @@ import (
 	"log"
 	"os"
 
-	common "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/common/v1"
+	api "github.com/deepgram/deepgram-go-sdk/v3/pkg/api/listen/v2/websocket/interfaces"
 	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces"
+	client "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/listen/v2"
 )
+
+type MyHandler struct{}
+
+func (MyHandler) Open(*api.OpenResponse) error              { return nil }
+func (MyHandler) Connected(cr *api.ConnectedResponse) error { fmt.Println("ready:", cr.RequestID); return nil }
+func (MyHandler) TurnInfo(tr *api.TurnInfoResponse) error {
+	if tr.EventType == api.TurnEventEndOfTurn {
+		fmt.Printf("[Turn %d] FINAL: %s\n", tr.TurnIndex, tr.Transcript)
+	}
+	return nil
+}
+func (MyHandler) ConfigureSuccess(*api.ConfigureSuccessResponse) error { return nil }
+func (MyHandler) ConfigureFailure(*api.ConfigureFailureResponse) error { return nil }
+func (MyHandler) FatalError(fe *api.FatalErrorResponse) error          { return fmt.Errorf("fatal: %s", fe.Description) }
+func (MyHandler) Close(*api.CloseResponse) error                       { return nil }
+func (MyHandler) Error(er *api.ErrorResponse) error                    { return fmt.Errorf("error: %s", er.ErrMsg) }
+func (MyHandler) UnhandledEvent([]byte) error                          { return nil }
 
 func main() {
 	if err := run(); err != nil {
@@ -46,53 +61,85 @@ func main() {
 func run() error {
 	ctx := context.Background()
 
-	// 1. Build client options with v2 path override
-	opts := interfaces.ClientOptions{
-		APIKey: os.Getenv("DEEPGRAM_API_KEY"),
-		Host:   "api.deepgram.com",
-		Path:   "/v2/listen", // override default v1 path
+	cOptions := &interfaces.ClientOptionsV2{EnableKeepAlive: true}
+	tOptions := &interfaces.FluxTranscriptionOptions{
+		Model:             "flux-general-en",
+		Encoding:          "linear16",
+		SampleRate:        16000,
+		EagerEotThreshold: 0.3,
 	}
 
-	// 2. Create a raw WS connection using shared plumbing
-	ws := common.New(ctx, "", &opts)
-
-	// 3. Connect and validate
-	if ok := ws.Connect(); !ok {
-		return fmt.Errorf("v2 WebSocket connect failed — verify API key and endpoint")
+	dg, err := client.NewWSUsingCallback(ctx, os.Getenv("DEEPGRAM_API_KEY"), cOptions, tOptions, MyHandler{})
+	if err != nil {
+		return err
 	}
-	defer ws.Stop()
+	defer dg.Stop()
 
-	// 4. Start read/write pumps
-	ws.Start()
+	if ok := dg.Connect(); !ok {
+		return fmt.Errorf("Flux WebSocket connect failed")
+	}
 
-	// 5. Stream PCM audio frames
-	//    for chunk := range audioSource { ws.WriteBinary(chunk) }
-
-	// 6. Finalize and shut down
-	//    ws.Finalize()
+	// Stream PCM audio frames:
+	//   for chunk := range audioSource { dg.WriteBinary(chunk) }
 	return nil
 }
 ```
 
-**Treat this as a manual integration**, not an SDK-supported surface. Do not invent `listen/v2` package paths or constructors.
+## WebSocket lifecycle
 
-## Key files for raw integration
+Follow these steps in order:
 
-| Purpose | File |
-|---------|------|
-| Shared WS lifecycle and reconnect | `pkg/client/common/v1/websocket.go` |
-| Client option types (host, path overrides) | `pkg/client/interfaces/v1/types-client.go` |
-| Version and path constants | `pkg/api/version/live-version.go`, `pkg/api/version/constants.go` |
+1. **Construct** -- `client.NewWSUsingCallback(ctx, apiKey, cOptions, tOptions, callback)` or `client.NewWSUsingChan(ctx, apiKey, cOptions, tOptions, chans)` (returns `conn, err`)
+2. **Connect** -- `conn.Connect()` returns `bool`; fail if `false`
+3. **Stream** -- send PCM chunks: `conn.WriteBinary(chunk)` (check returned `error`)
+4. **KeepAlive** -- set `ClientOptionsV2{EnableKeepAlive: true}` to auto-send keepalives during idle periods
+5. **Reconfigure** -- call `conn.Configure(&interfaces.FluxConfigureOptions{...})` to adjust thresholds mid-session without reconnecting
+6. **Stop** -- `defer conn.Stop()` near construction
+
+## Turn lifecycle events
+
+`TurnInfo` fires for every turn-detection event. Inspect `TurnInfoResponse.EventType`:
+
+| EventType | Meaning |
+|-----------|---------|
+| `TurnEventStartOfTurn` | New speech turn detected |
+| `TurnEventUpdate` | Interim transcript update |
+| `TurnEventEagerEndOfTurn` | Early end-of-turn signal (fires when `EagerEotThreshold` is set) |
+| `TurnEventTurnResumed` | Speaker continued after an eager EOT -- treat the prior eager final as not final |
+| `TurnEventEndOfTurn` | Final transcript for the turn |
+
+## Channel client (alternative)
+
+When goroutine-per-event ergonomics are preferred over a callback struct, use `client.NewWSUsingChan(...)` with an implementation of `api.FluxMessageChan`. Each `GetX()` getter returns `[]*chan *XResponse`; return `nil` for events you don't care about. See `examples/speech-to-text/websocket/flux_channel/main.go` for the full pattern.
+
+## Key parameters
+
+| Layer | Types / Fields |
+|-------|---------------|
+| Transcription options | `interfaces.FluxTranscriptionOptions` -- `Model` (`flux-general-en`, `flux-general-multi`), `Encoding`, `SampleRate`, `EagerEotThreshold` (0.3-0.9), `EotThreshold` (0.5-0.9, default 0.7), `EotTimeoutMs` (500-10000, default 5000), `Keyterm`, `LanguageHint`, `Tag`, `MipOptOut` |
+| Client options | `interfaces.ClientOptionsV2` -- `APIKey`, `EnableKeepAlive`, host/path overrides |
+| Mid-session config | `interfaces.FluxConfigureOptions` -- `Thresholds` (`*FluxThresholds`), `Keyterms`, `LanguageHints` |
+| Callback constructors | `client.NewWSUsingCallback`, `NewWSUsingCallbackWithDefaults`, `NewWSUsingCallbackForDemo`, `NewWSUsingCallbackWithCancel` |
+| Channel constructors | `client.NewWSUsingChan`, `NewWSUsingChanWithDefaults`, `NewWSUsingChanForDemo`, `NewWSUsingChanWithCancel` |
+| Callback contract | `api.FluxMessageCallback` -- `Open`, `Connected`, `TurnInfo`, `ConfigureSuccess`, `ConfigureFailure`, `FatalError`, `Close`, `Error`, `UnhandledEvent` |
+| Channel contract | `api.FluxMessageChan` -- `GetOpen`, `GetConnected`, `GetTurnInfo`, `GetConfigureSuccess`, `GetConfigureFailure`, `GetFatalError`, `GetClose`, `GetError`, `GetUnhandled` |
 
 ## API reference (layered)
 
-1. In-repo: `pkg/client/common/v1/websocket.go`, `pkg/client/interfaces/v1/types-client.go`, `pkg/api/version/live-version.go`
+1. In-repo: `pkg/client/listen/v2/client.go`, `pkg/client/listen/v2/websocket/{new_using_callbacks,new_using_chan,client_callback,client_channel,types}.go`, `pkg/client/interfaces/v2/types-flux.go`, `pkg/api/listen/v2/websocket/interfaces/interfaces.go`
 2. OpenAPI: `https://developers.deepgram.com/openapi.yaml`
 3. AsyncAPI: `https://developers.deepgram.com/asyncapi.yaml`
-4. Product docs: `https://developers.deepgram.com/docs/conversational-speech-recognition`
+4. Product docs: `https://developers.deepgram.com/docs/flux`
 
 ## Gotchas
 
-1. Conversational STT v2 is **not** a first-class Go SDK client here. Do not invent `listen/v2` constructors.
-2. If production-ready Flux support is required, point to raw API usage or another SDK.
-3. For WS reconnect and keepalive patterns, see `tests/edge_cases/keepalive/main.go` and `tests/edge_cases/reconnect_client/main.go`.
+1. `Connect()` returns `bool`, not `error` -- always check it.
+2. `Model` is required on `FluxTranscriptionOptions`; `LanguageHint` only applies when `Model` is `flux-general-multi`.
+3. Set `EagerEotThreshold` only if your UX consumes `TurnEventEagerEndOfTurn` -- otherwise stick to `EotThreshold` and the final `TurnEventEndOfTurn`.
+4. After `TurnEventEagerEndOfTurn`, a `TurnEventTurnResumed` may arrive; don't commit the eager transcript as final until `TurnEventEndOfTurn` fires.
+5. Callback and channel variants are mutually exclusive per connection; pick one per session.
+
+## Example files
+
+- `examples/speech-to-text/websocket/flux_callback/main.go`
+- `examples/speech-to-text/websocket/flux_channel/main.go`

--- a/.agents/skills/deepgram-go-speech-to-text/SKILL.md
+++ b/.agents/skills/deepgram-go-speech-to-text/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: deepgram-go-speech-to-text
-description: Use when writing or reviewing Go code in this repo that transcribes prerecorded audio with Listen v1 REST or streams live audio with Listen v1 WebSockets. Route text generation to deepgram-go-text-to-speech, text analysis to deepgram-go-text-intelligence, audio analytics overlays to deepgram-go-audio-intelligence, and Flux or other v2 conversational work to deepgram-go-conversational-stt.
+description: "Use when writing or reviewing Go code in this repo that transcribes prerecorded audio with Listen v1 REST or streams live audio with Listen v1 WebSockets. Route text generation to deepgram-go-text-to-speech, text analysis to deepgram-go-text-intelligence, audio analytics overlays to deepgram-go-audio-intelligence, and Flux v2 conversational work to deepgram-go-conversational-stt."
 ---
 
 # Using Deepgram Speech-to-Text from the Go SDK
 
-## When to use this product
-
-Use this skill for `pkg/client/listen` work:
-
-- prerecorded transcription with `FromURL`, `FromFile`, or `FromStream`
-- live transcription with `pkg/client/listen/v1/websocket`
-- channel-based or callback-based streaming flows
+Use this skill for `pkg/client/listen` work: prerecorded transcription (`FromURL`, `FromFile`, `FromStream`), live transcription via WebSocket, and channel or callback streaming flows.
 
 Use a different skill when:
 
@@ -22,17 +16,11 @@ Use a different skill when:
 
 ## Authentication
 
-Set `DEEPGRAM_API_KEY` before constructing clients.
-
 ```bash
 export DEEPGRAM_API_KEY="your_api_key"
 ```
 
-This SDK reads env-backed defaults via the client option layer. Prefer API key or token auth supported by the repo's client options; do not hardcode credentials.
-
-## Quick start
-
-Prerecorded REST:
+## Quick start -- prerecorded REST
 
 ```go
 package main
@@ -77,28 +65,21 @@ func run() error {
 }
 ```
 
-Live WebSocket with channel fan-out:
+## Live WebSocket -- lifecycle
+
+Follow these steps in order:
+
+1. **Construct** -- `listen.NewWSUsingChanWithDefaults(ctx, opts, handler)` (returns `conn, err`)
+2. **Connect** -- `conn.Connect()` returns `bool`; fail if `false`
+3. **Start** -- `conn.Start()` launches read/write pumps
+4. **Stream** -- send PCM chunks: `conn.WriteBinary(chunk)` (check returned `error`)
+5. **KeepAlive** -- call `conn.KeepAlive()` during idle periods to prevent timeout
+6. **Finalize** -- `conn.Finalize()` flushes trailing audio; check `error`
+7. **Stop** -- `defer conn.Stop()` near construction
 
 ```go
-package main
-
-import (
-	"context"
-	"fmt"
-	"log"
-
-	listenws "github.com/deepgram/deepgram-go-sdk/v3/pkg/api/listen/v1/websocket"
-	listen "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/listen"
-	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces"
-)
-
-func main() {
-	if err := run(); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func run() error {
+// After imports: listenws, listen, interfaces (same pattern as REST)
+func runWS() error {
 	ctx := context.Background()
 	handler := listenws.NewDefaultChanHandler()
 
@@ -113,84 +94,45 @@ func run() error {
 	defer conn.Stop()
 
 	if ok := conn.Connect(); !ok {
-		return fmt.Errorf("connect failed")
+		return fmt.Errorf("STT WebSocket connect failed")
 	}
-
 	conn.Start()
 
-	// The handler receives Open/Message/Metadata/UtteranceEnd events.
-	// In a real app, stream PCM/audio chunks from your mic or file reader here.
-	// For example (pseudo-code):
-	//   for chunk := range audioChunks {
-	//       if err := conn.WriteBinary(chunk); err != nil { return err }
-	//   }
-	//
-	// When the input stream ends, flush any trailing audio and close cleanly:
-	//   if err := conn.Finalize(); err != nil { return err }
-
+	// Stream audio and finalize when done:
+	//   for chunk := range audioSource { conn.WriteBinary(chunk) }
+	//   conn.Finalize()
 	return nil
 }
 ```
 
 ## Key parameters
 
-- `interfaces.PreRecordedTranscriptionOptions`
-	- common fields: `Model`, `Language`, `Punctuate`, `SmartFormat`, `Diarize`, `Redact`, `Utterances`
-	- use with `pkg/api/listen/v1/rest`: `api.New(client).FromURL`, `FromFile`, `FromStream`
-- `interfaces.LiveTranscriptionOptions`
-	- common fields: `Model`, `Language`, `Encoding`, `SampleRate`, `Channels`, `InterimResults`, `Endpointing`
-- constructor families
-	- REST: `listen.NewRESTWithDefaults()`, `listen.NewREST(apiKey, options)`
-  - WS callbacks: `listen.NewWSUsingCallback...`
-  - WS channels: `listen.NewWSUsingChan...`
-- lifecycle
-	- `Connect()` returns `bool`; call `Start()`, stream/write audio, `KeepAlive()` as needed, `Finalize()`, then `defer conn.Stop()`
+| Layer | Types / Fields |
+|-------|---------------|
+| Prerecorded options | `interfaces.PreRecordedTranscriptionOptions` -- `Model`, `Language`, `Punctuate`, `SmartFormat`, `Diarize`, `Redact`, `Utterances` |
+| Live options | `interfaces.LiveTranscriptionOptions` -- `Model`, `Language`, `Encoding`, `SampleRate`, `Channels`, `InterimResults`, `Endpointing` |
+| REST constructors | `listen.NewRESTWithDefaults()`, `listen.NewREST(apiKey, options)` |
+| WS constructors | `listen.NewWSUsingCallback...`, `listen.NewWSUsingChan...` |
+| REST methods | `api.New(client).FromURL`, `FromFile`, `FromStream` |
 
 ## API reference (layered)
 
-1. In-repo reference
-   - `README.md`
-   - `docs.go`
-   - `pkg/client/listen/client.go`
-   - `pkg/client/listen/v1/rest/client.go`
-   - `pkg/client/listen/v1/websocket/client_callback.go`
-   - `pkg/client/listen/v1/websocket/client_channel.go`
-   - `pkg/client/interfaces/v1/types-prerecorded.go`
-   - `pkg/client/interfaces/v1/types-stream.go`
-2. OpenAPI
-   - `https://developers.deepgram.com/openapi.yaml`
-3. AsyncAPI
-   - `https://developers.deepgram.com/asyncapi.yaml`
-4. Context7
-   - `/llmstxt/developers_deepgram_llms_txt`
-5. Product docs
-   - `https://developers.deepgram.com/reference/speech-to-text/listen-pre-recorded`
-   - `https://developers.deepgram.com/reference/speech-to-text/listen-streaming`
-   - `https://developers.deepgram.com/docs/speech-to-text`
+1. In-repo: `pkg/client/listen/client.go`, `pkg/client/listen/v1/rest/client.go`, `pkg/client/listen/v1/websocket/client_channel.go`, `pkg/client/interfaces/v1/types-prerecorded.go`, `pkg/client/interfaces/v1/types-stream.go`
+2. OpenAPI: `https://developers.deepgram.com/openapi.yaml`
+3. Product docs: `https://developers.deepgram.com/reference/speech-to-text/listen-pre-recorded`, `https://developers.deepgram.com/reference/speech-to-text/listen-streaming`
 
 ## Gotchas
 
 1. This repo uses `listen` package names for STT v1, not `transcription`.
-2. Streaming code is split into callback and channel variants; copy the style that matches the surrounding package.
-3. For WebSockets, pass a handler into `NewWSUsingChan...`, keep `defer conn.Stop()` near construction, and finalize before shutdown.
-4. Live and prerecorded option structs are different; do not assume analytics-only prerecorded fields exist in live mode.
-5. Use `context.Context` and return `error`; do not translate examples into exception-style control flow.
+2. Streaming code is split into callback and channel variants; match the surrounding package style.
+3. Live and prerecorded option structs are different; analytics-only fields (e.g. `Summarize`) exist only on prerecorded.
+4. `Connect()` returns `bool`, not `error` -- always check it.
+5. Always call `Finalize()` before `Stop()` to flush trailing audio.
 
-## Example files in this repo
+## Example files
 
 - `examples/speech-to-text/rest/url/main.go`
 - `examples/speech-to-text/rest/file/main.go`
 - `examples/speech-to-text/websocket/microphone_channel/main.go`
 - `examples/speech-to-text/websocket/microphone_callback/main.go`
 - `tests/edge_cases/keepalive/main.go`
-- `tests/edge_cases/reconnect_client/main.go`
-
-## Central product skills
-
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).

--- a/.agents/skills/deepgram-go-text-to-speech/SKILL.md
+++ b/.agents/skills/deepgram-go-text-to-speech/SKILL.md
@@ -1,44 +1,33 @@
 ---
 name: deepgram-go-text-to-speech
-description: Use when writing or reviewing Go code in this repo that synthesizes audio with Speak v1 REST or Speak WebSockets. Route transcription work to deepgram-go-speech-to-text, voice conversation runtime work to deepgram-go-voice-agent, and repository maintenance work to deepgram-go-maintaining-sdk.
+description: "Use when writing or reviewing Go code in this repo that synthesizes audio with Speak v1 REST or Speak WebSockets -- configure output formats, save to file, stream low-latency audio, and manage WebSocket playback pipelines. Route transcription to deepgram-go-speech-to-text and voice conversation runtime to deepgram-go-voice-agent."
 ---
 
 # Using Deepgram Text-to-Speech from the Go SDK
 
-## When to use this product
-
-Use this skill for `pkg/client/speak` work:
-
-- file or stream synthesis over REST
-- low-latency synthesis over WebSockets
-- callback-based or channel-based audio playback pipelines
+Use this skill for `pkg/client/speak` work: file/stream synthesis over REST, low-latency synthesis over WebSockets, callback or channel audio playback.
 
 Use a different skill when:
 
 - you need STT (`deepgram-go-speech-to-text`)
 - you need live voice-agent orchestration (`deepgram-go-voice-agent`)
-- you need repo workflow guidance (`deepgram-go-maintaining-sdk`)
 
 ## Authentication
-
-Set `DEEPGRAM_API_KEY` before creating Speak clients.
 
 ```bash
 export DEEPGRAM_API_KEY="your_api_key"
 ```
 
-Use the repo's env-backed client defaults instead of embedding secrets in code.
-
-## Quick start
-
-REST synthesis to file:
+## Quick start -- REST synthesis to file
 
 ```go
 package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
 
 	api "github.com/deepgram/deepgram-go-sdk/v3/pkg/api/speak/v1/rest"
 	speak "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/speak"
@@ -66,32 +55,20 @@ func run() error {
 		return err
 	}
 
+	// Validate output was written
+	info, err := os.Stat("hello.wav")
+	if err != nil || info.Size() == 0 {
+		return fmt.Errorf("output file missing or empty")
+	}
 	return nil
 }
 ```
 
-Streaming synthesis with callbacks or channels:
+## Streaming synthesis over WebSocket
 
 ```go
-package main
-
-import (
-	"context"
-	"fmt"
-	"log"
-
-	speakws "github.com/deepgram/deepgram-go-sdk/v3/pkg/api/speak/v1/websocket"
-	speak "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/speak"
-	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces"
-)
-
-func main() {
-	if err := run(); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func run() error {
+// After imports: speakws, speak, interfaces (same pattern as REST)
+func runWS() error {
 	ctx := context.Background()
 	handler := speakws.NewDefaultChanHandler()
 
@@ -106,80 +83,47 @@ func run() error {
 	defer conn.Stop()
 
 	if ok := conn.Connect(); !ok {
-		return fmt.Errorf("connect failed")
+		return fmt.Errorf("TTS WebSocket connect failed")
 	}
-
 	conn.Start()
 
 	if err := conn.SpeakWithText("Streaming TTS from Go."); err != nil {
 		return err
 	}
-
-	// The handler receives binary audio and flow-control events.
+	// Flush waits for the server to confirm all audio has been sent
 	if err := conn.Flush(); err != nil {
 		return err
 	}
-
 	return nil
 }
 ```
 
 ## Key parameters
 
-- `interfaces.SpeakOptions`
-  - typical fields: `Model`, `Encoding`, `Container`, `SampleRate`
-- `interfaces.WSSpeakOptions`
-	- typical fields: `Model`, streaming audio format settings
-- REST methods
-	- via `pkg/api/speak/v1/rest`: `api.New(client).ToStream`, `ToFile`, `ToSave`
-- WS methods
-	- `SpeakWithText`, `Speak`, `Flush`, `Reset`
-- constructors
-	- `speak.NewRESTWithDefaults()` / `speak.NewREST(...)`
-	- `speak.NewWSUsingCallback...`
-	- `speak.NewWSUsingChan...`
+| Layer | Types / Methods |
+|-------|----------------|
+| REST options | `interfaces.SpeakOptions` -- `Model`, `Encoding`, `Container`, `SampleRate` |
+| WS options | `interfaces.WSSpeakOptions` -- `Model`, streaming format settings |
+| REST methods | `api.New(client).ToStream`, `ToFile`, `ToSave` |
+| WS methods | `SpeakWithText`, `Speak`, `Flush`, `Reset` |
+| REST constructors | `speak.NewRESTWithDefaults()`, `speak.NewREST(...)` |
+| WS constructors | `speak.NewWSUsingCallback...`, `speak.NewWSUsingChan...` |
 
 ## API reference (layered)
 
-1. In-repo reference
-   - `README.md`
-   - `docs.go`
-   - `pkg/client/speak/client.go`
-   - `pkg/client/speak/v1/rest/client.go`
-   - `pkg/client/speak/v1/websocket/client_callback.go`
-   - `pkg/client/speak/v1/websocket/client_channel.go`
-   - `pkg/client/interfaces/v1/types-speak.go`
-2. OpenAPI
-   - `https://developers.deepgram.com/openapi.yaml`
-3. AsyncAPI
-   - `https://developers.deepgram.com/asyncapi.yaml`
-4. Context7
-   - `/llmstxt/developers_deepgram_llms_txt`
-5. Product docs
-   - `https://developers.deepgram.com/reference/text-to-speech/speak-request`
-   - `https://developers.deepgram.com/reference/text-to-speech/speak-streaming`
-   - `https://developers.deepgram.com/docs/tts-models`
+1. In-repo: `pkg/client/speak/client.go`, `pkg/client/speak/v1/rest/client.go`, `pkg/client/speak/v1/websocket/client_channel.go`, `pkg/client/interfaces/v1/types-speak.go`
+2. OpenAPI: `https://developers.deepgram.com/openapi.yaml`
+3. Product docs: `https://developers.deepgram.com/reference/text-to-speech/speak-request`, `https://developers.deepgram.com/docs/tts-models`
 
 ## Gotchas
 
-1. REST and WebSocket Speak clients use different option structs.
-2. REST methods live on `pkg/api/speak/v1/rest`; build them with `api.New(client)`.
-3. WebSocket flows use a handler passed at construction, `Connect()` returns `bool`, and shutdown is `Stop()`.
-4. Keep the playback or message-consumer goroutine running while audio frames arrive.
-5. Follow the examples for file handling and output format selection instead of guessing encodings.
+1. REST and WebSocket Speak clients use **different option structs** (`SpeakOptions` vs `WSSpeakOptions`).
+2. `Connect()` returns `bool`, not `error` -- always check it.
+3. Keep the playback or message-consumer goroutine running while audio frames arrive on the WS handler.
+4. Follow the in-repo examples for output format selection instead of guessing encodings.
 
-## Example files in this repo
+## Example files
 
 - `examples/text-to-speech/rest/file/hello-world/main.go`
 - `examples/text-to-speech/websocket/simple_channel/main.go`
 - `examples/text-to-speech/websocket/simple_callback/main.go`
-
-## Central product skills
-
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).

--- a/.agents/skills/deepgram-go-voice-agent/SKILL.md
+++ b/.agents/skills/deepgram-go-voice-agent/SKILL.md
@@ -1,19 +1,11 @@
 ---
 name: deepgram-go-voice-agent
-description: Use when writing or reviewing Go code in this repo that runs a Deepgram Voice Agent session over WebSockets, including runtime settings, prompt updates, speak updates, injected messages, and event handling. Route standalone STT/TTS work to deepgram-go-speech-to-text or deepgram-go-text-to-speech.
+description: "Use when writing or reviewing Go code in this repo that runs a Deepgram Voice Agent session over WebSockets, including runtime settings, prompt updates, speak updates, injected messages, and event handling. Route standalone STT/TTS work to deepgram-go-speech-to-text or deepgram-go-text-to-speech."
 ---
 
 # Using Deepgram Voice Agent from the Go SDK
 
-## When to use this product
-
 Use this skill for live Voice Agent runtime flows in `pkg/client/agent`.
-
-- open an agent WebSocket session
-- send initial settings
-- stream audio
-- react to agent events and function-call messages
-- update prompt/speak settings during the session
 
 Use a different skill when:
 
@@ -23,13 +15,24 @@ Use a different skill when:
 
 ## Authentication
 
-Set `DEEPGRAM_API_KEY` before opening the agent connection.
-
 ```bash
 export DEEPGRAM_API_KEY="your_api_key"
 ```
 
-## Quick start
+## Session lifecycle
+
+Follow these steps in order:
+
+1. **Configure** -- build settings with `agent.NewSettingsConfigurationOptions()`
+2. **Connect** -- call `conn.Connect()` (returns `bool`; fail if `false`)
+3. **Start** -- call `conn.Start()` to launch read/write pumps
+4. **Stream audio** -- send PCM chunks via `conn.WriteBinary(chunk)`
+5. **Handle events** -- read from the channel handler (see example below)
+6. **Runtime updates** -- call `conn.ProcessMessage(msg)` with `UpdatePrompt`, `UpdateSpeak`, `InjectAgentMessage`, or `InjectUserMessage`
+7. **Respond to function calls** -- send `FunctionCallResponse` when you receive `FunctionCallRequestResponse`
+8. **Shut down** -- `defer conn.Stop()` near construction
+
+## Quick start -- connection and event loop
 
 ```go
 package main
@@ -61,76 +64,70 @@ func run() error {
 	defer conn.Stop()
 
 	if ok := conn.Connect(); !ok {
-		return fmt.Errorf("connect failed")
+		return fmt.Errorf("agent WebSocket connect failed")
 	}
-
 	conn.Start()
 
-	// The handler receives Welcome, ConversationText, FunctionCallRequest, and audio events.
-	// Stream audio frames, watch agent events, and respond to function calls as needed.
+	// Event handling loop -- run concurrently alongside audio streaming.
+	go func() {
+		for {
+			select {
+			case welcome := <-handler.GetWelcome():
+				fmt.Printf("Session started: %s\n", welcome.SessionID)
+			case text := <-handler.GetConversationText():
+				fmt.Printf("[%s] %s\n", text.Role, text.Content)
+			case fcReq := <-handler.GetFunctionCallRequest():
+				// Respond to function calls:
+				resp := &agentws.FunctionCallResponse{
+					FunctionCallID: fcReq.FunctionCallID,
+					Output:         `{"result": "ok"}`,
+				}
+				if err := conn.ProcessMessage(ctx, resp); err != nil {
+					log.Printf("function call response error: %v", err)
+				}
+			case <-handler.GetUnhandled():
+				// Log or ignore unrecognized events
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Stream audio frames from your mic or file reader:
+	//   for chunk := range audioSource { conn.WriteBinary(chunk) }
+
+	// Runtime updates mid-session:
+	//   conn.ProcessMessage(ctx, &agentws.UpdatePrompt{Prompt: "new system prompt"})
+	//   conn.ProcessMessage(ctx, &agentws.InjectAgentMessage{Content: "Hello!"})
+
 	return nil
 }
 ```
 
 ## Key parameters
 
-- constructors
-	- `agent.NewSettingsConfigurationOptions()`
-	- `agent.NewWSUsingChanWithDefaults(...)`
-	- `agent.NewWSUsingChan(...)`
-- runtime methods
-	- `Connect`, `Start`, `ProcessMessage`, `Stream`, `Write`, `KeepAlive`
-	- reconnect helpers like `AttemptReconnect` and error handling helpers in the WS client
-- message and event payloads in `pkg/api/agent/v1/websocket/interfaces/types.go`
-  - `UpdatePrompt`
-  - `UpdateSpeak`
-  - `InjectAgentMessage`
-  - `InjectUserMessage`
-  - `FunctionCallResponse`
-  - server events such as `WelcomeResponse`, `ConversationTextResponse`, `FunctionCallRequestResponse`, `AgentStartedSpeakingResponse`, `AgentAudioDoneResponse`
+- constructors: `agent.NewSettingsConfigurationOptions()`, `agent.NewWSUsingChanWithDefaults(...)`, `agent.NewWSUsingChan(...)`
+- runtime methods: `Connect`, `Start`, `ProcessMessage`, `Stream`, `WriteBinary`, `KeepAlive`, `AttemptReconnect`
+- event/message types in `pkg/api/agent/v1/websocket/interfaces/types.go`:
+  `WelcomeResponse`, `ConversationTextResponse`, `FunctionCallRequestResponse`, `AgentStartedSpeakingResponse`, `AgentAudioDoneResponse`, `UpdatePrompt`, `UpdateSpeak`, `InjectAgentMessage`, `InjectUserMessage`, `FunctionCallResponse`
 
 ## API reference (layered)
 
-1. In-repo reference
-   - `README.md`
-   - `pkg/client/agent/client.go`
-   - `pkg/client/agent/v1/websocket/client_channel.go`
-   - `pkg/client/agent/v1/websocket/new_using_chan.go`
-   - `pkg/client/interfaces/v1/types-agent.go`
-   - `pkg/api/agent/v1/websocket/interfaces/types.go`
-2. OpenAPI
-   - `https://developers.deepgram.com/openapi.yaml`
-3. AsyncAPI
-   - `https://developers.deepgram.com/asyncapi.yaml`
-4. Context7
-   - `/llmstxt/developers_deepgram_llms_txt`
-5. Product docs
-   - `https://developers.deepgram.com/reference/voice-agent/voice-agent`
-   - `https://developers.deepgram.com/docs/voice-agent`
-   - `https://developers.deepgram.com/docs/configure-voice-agent`
-   - `https://developers.deepgram.com/docs/voice-agent-message-flow`
+1. In-repo: `pkg/client/agent/client.go`, `pkg/client/agent/v1/websocket/client_channel.go`, `pkg/client/interfaces/v1/types-agent.go`, `pkg/api/agent/v1/websocket/interfaces/types.go`
+2. OpenAPI: `https://developers.deepgram.com/openapi.yaml`
+3. AsyncAPI: `https://developers.deepgram.com/asyncapi.yaml`
+4. Product docs: `https://developers.deepgram.com/docs/voice-agent`, `https://developers.deepgram.com/docs/voice-agent-message-flow`
 
 ## Gotchas
 
-1. This repo exposes live Voice Agent runtime over WebSockets, not a persisted configuration-management surface.
-2. Keep audio streaming, event handling, and any function-call response loop running concurrently.
-3. Follow the example session setup instead of inventing your own event names; the repo already defines concrete message structs.
-4. Channel-based constructors require an `AgentMessageChan` handler; events are routed there rather than pulled from the client.
-5. Use `defer conn.Stop()`, and remember that `Connect()` returns `bool` rather than `error`.
+1. `Connect()` returns `bool`, not `error` -- always check it.
+2. Keep audio streaming and the event-handling goroutine running concurrently; blocking either stalls the session.
+3. Channel-based constructors require an `AgentMessageChan` handler; events are routed there, not pulled from the client.
+4. Use the concrete message structs defined in the repo -- do not invent custom event names.
 
-## Example files in this repo
+## Example files
 
 - `examples/agent/websocket/simple/main.go`
 - `examples/agent/websocket/no_mic/main.go`
 - `examples/agent/websocket/arbitrary_keys/main.go`
 - `tests/unit_test/agent/agent_speak_test.go`
-
-## Central product skills
-
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).


### PR DESCRIPTION
Hey @deepgram 👋

I ran your skills through `tessl skill review` at work and found targeted improvements in your skills. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| deepgram-go-voice-agent | 78% | 100% | +22% |
| deepgram-go-text-to-speech | 85% | 100% | +15% |
| deepgram-go-speech-to-text | 89% | 100% | +11% |
| deepgram-go-conversational-stt | 73% | 83% | +10% |
| deepgram-go-audio-intelligence | 94% | 100% | +6% |

These were easy changes to bring the skill's structure and activation in line with what performs well against Anthropic's best practices. Added concrete code examples, sequenced workflows with validation checkpoints, condensed verbose sections.

In addition, I stress-tested your [`deepgram-go-conversational-stt` skill against a few real-world scenarios](https://tessl.io/registry/skills/github/deepgram/deepgram-go-sdk/deepgram-go-conversational-stt/evals), and it held up really well. This means that your skill meaningfully improves agent steering and contributes to stronger output quality. Kudos for that!

Honest disclosure, I work at @tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

If you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@rohan-tessl](https://github.com/rohan-tessl), if you hit any snags.