### PR TITLE
feat: add diarize_model option to pre-recorded transcription

### DIFF
--- a/.agents/skills/deepgram-go-audio-intelligence/SKILL.md
+++ b/.agents/skills/deepgram-go-audio-intelligence/SKILL.md
@@ -88,6 +88,7 @@ func run() error {
   - `DetectLanguage`
   - `DetectEntities`
   - `Diarize`
+  - `DiarizeModel`
   - `Redact`
 - response payloads are in `pkg/api/listen/v1/rest/interfaces/types.go`
   - `Sentiments`

--- a/.agents/skills/deepgram-go-speech-to-text/SKILL.md
+++ b/.agents/skills/deepgram-go-speech-to-text/SKILL.md
@@ -135,7 +135,7 @@ func run() error {
 ## Key parameters
 
 - `interfaces.PreRecordedTranscriptionOptions`
-	- common fields: `Model`, `Language`, `Punctuate`, `SmartFormat`, `Diarize`, `Redact`, `Utterances`
+	- common fields: `Model`, `Language`, `Punctuate`, `SmartFormat`, `Diarize`, `DiarizeModel` (batch diarization version: `latest`/`v1`/`v2`), `Redact`, `Utterances`
 	- use with `pkg/api/listen/v1/rest`: `api.New(client).FromURL`, `FromFile`, `FromStream`
 - `interfaces.LiveTranscriptionOptions`
 	- common fields: `Model`, `Language`, `Encoding`, `SampleRate`, `Channels`, `InterimResults`, `Endpointing`

--- a/pkg/client/interfaces/v1/types-prerecorded.go
+++ b/pkg/client/interfaces/v1/types-prerecorded.go
@@ -24,6 +24,7 @@ type PreRecordedTranscriptionOptions struct {
 	DetectLanguage   bool     `json:"detect_language,omitempty" schema:"detect_language,omitempty"`
 	DetectTopics     bool     `json:"detect_topics,omitempty" schema:"detect_topics,omitempty"`
 	Diarize          bool     `json:"diarize,omitempty" schema:"diarize,omitempty"`
+	DiarizeModel     string   `json:"diarize_model,omitempty" schema:"diarize_model,omitempty"`
 	DiarizeVersion   string   `json:"diarize_version,omitempty" schema:"diarize_version,omitempty"`
 	Dictation        bool     `json:"dictation,omitempty" schema:"dictation,omitempty"`
 	Encoding         string   `json:"encoding,omitempty" schema:"encoding,omitempty"`

--- a/tests/unit_test/prerecorded_diarize_model_test.go
+++ b/tests/unit_test/prerecorded_diarize_model_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package deepgram_test
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	version "github.com/deepgram/deepgram-go-sdk/v3/pkg/api/version"
+	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces"
+)
+
+// Test_PrerecordedDiarizeModel verifies that setting DiarizeModel on the
+// pre-recorded (batch) transcription options serializes to the diarize_model
+// query parameter on the outgoing POST /v1/listen request.
+func Test_PrerecordedDiarizeModel(t *testing.T) {
+	t.Run("diarize_model=v2 appears in the batch request query string", func(t *testing.T) {
+		uri, err := version.GetPrerecordedAPI(
+			context.Background(),
+			"",
+			"",
+			"",
+			&interfaces.PreRecordedTranscriptionOptions{
+				Model:        "nova-2",
+				DiarizeModel: "v2",
+			})
+		if err != nil {
+			t.Fatalf("GetPrerecordedAPI should succeed, but got %s", err)
+		}
+
+		parsed, err := url.Parse(uri)
+		if err != nil {
+			t.Fatalf("failed to parse generated URI %q: %s", uri, err)
+		}
+
+		if got := parsed.Query().Get("diarize_model"); got != "v2" {
+			t.Errorf("expected diarize_model=v2 in query string, got %q (full URI: %s)", got, uri)
+		}
+	})
+
+	// v1 and latest are also valid per the API spec (enum: latest, v1, v2).
+	for _, value := range []string{"v1", "latest"} {
+		value := value
+		t.Run("diarize_model="+value+" appears in the batch request query string", func(t *testing.T) {
+			uri, err := version.GetPrerecordedAPI(
+				context.Background(),
+				"",
+				"",
+				"",
+				&interfaces.PreRecordedTranscriptionOptions{
+					DiarizeModel: value,
+				})
+			if err != nil {
+				t.Fatalf("GetPrerecordedAPI should succeed, but got %s", err)
+			}
+			if !strings.Contains(uri, "diarize_model="+value) {
+				t.Errorf("expected diarize_model=%s in query string, got URI: %s", value, uri)
+			}
+		})
+	}
+
+	// When DiarizeModel is unset it must not appear (omitempty), keeping the
+	// change additive and non-breaking for existing callers.
+	t.Run("diarize_model is omitted when unset", func(t *testing.T) {
+		uri, err := version.GetPrerecordedAPI(
+			context.Background(),
+			"",
+			"",
+			"",
+			&interfaces.PreRecordedTranscriptionOptions{
+				Model: "nova-2",
+			})
+		if err != nil {
+			t.Fatalf("GetPrerecordedAPI should succeed, but got %s", err)
+		}
+		if strings.Contains(uri, "diarize_model") {
+			t.Errorf("did not expect diarize_model in query string when unset, got URI: %s", uri)
+		}
+	})
+}

--- a/tests/unit_test/prerecorded_test.go
+++ b/tests/unit_test/prerecorded_test.go
@@ -65,6 +65,7 @@ func Test_PrerecordedFromURL(t *testing.T) {
 		"profanity_filter": {"true", "false"},
 		"redact":           {"true", "false", "pci", "ssn", "numbers"},
 		"diarize":          {"true", "false"},
+		"diarize_model":    {"latest", "v1", "v2"},
 		"diarize_version":  nil,
 		"smart_format":     {"true", "false"},
 		"multichannel":     {"true", "false"},


### PR DESCRIPTION
## What changed
- Added `DiarizeModel string` to `PreRecordedTranscriptionOptions` (`pkg/client/interfaces/v1/types-prerecorded.go`), tagged `json:"diarize_model,omitempty" schema:"diarize_model,omitempty"`, so gorilla/schema serializes it to the `diarize_model` query param on `POST /v1/listen`. Accepts `latest` / `v1` / `v2` (plain `string`, mirroring existing `model`/`diarize_version` fields and staying forward-compatible).
- Added focused unit tests asserting `diarize_model=v2` (plus `v1`/`latest`) lands in the outgoing query string and is omitted when unset; added `diarize_model` to the accepted-params map in the existing test. `go build`/`go vet`/`gofmt` clean; unit suite passes.

## Why
The playground needs to surface Diarization v2, and Go is a playground-supported SDK whose spec-driven regen isn't ready yet. This hand-written change bridges the gap; the regenerated SDK will pick up `diarize_model` natively later.

## Non-breaking
Additive only. The deprecated `diarize` boolean is untouched and the new field is `omitempty`. Batch-only: intentionally not added to `LiveTranscriptionOptions` or `FluxTranscriptionOptions`, since the API rejects `diarize_model` on streaming requests.