### PR TITLE
chore: add deepgram-kiley and dg-coreylweathers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Global code owners - these users will be requested for review on all API SPEC PRs
 # DX TEAM Members
-* @GregHolmes
+* @GregHolmes @deepgram-kiley @dg-coreylweathers
 
 # Future Reference: you can also specify owners for specific paths if needed:
 # /src/ @username1 @username2


### PR DESCRIPTION
Adds `@deepgram-kiley` and `@dg-coreylweathers` as global code owners alongside `@GregHolmes`.

```diff
- * @GregHolmes
+ * @GregHolmes @deepgram-kiley @dg-coreylweathers
```

Note: the new owners must have repo/org access for GitHub to honor them on review requests.