### PR TITLE
feat: add mandatory instruction rule for agent skill discovery #341

### DIFF
--- a/.agents/rules/INSTRUCTIONS.md
+++ b/.agents/rules/INSTRUCTIONS.md
@@ -8,4 +8,4 @@ Do not act on the user's request until you have read `.agents/skills/**`.
 It contains the rules that determine your first action based on what the user asked.
 Skipping it WILL cause you to take the wrong action.
 
-There are no instructions in this file. All instructions are in `.agents/skills/**`.
+There are no additional instructions in this file. All detailed instructions are in `.agents/skills/**`.

--- a/.agents/rules/INSTRUCTIONS.md
+++ b/.agents/rules/INSTRUCTIONS.md
@@ -1,0 +1,11 @@
+---
+trigger: always_on
+---
+
+MANDATORY: Read `.agents/skills/**` before responding to ANY user message.
+
+Do not act on the user's request until you have read `.agents/skills/**`.
+It contains the rules that determine your first action based on what the user asked.
+Skipping it WILL cause you to take the wrong action.
+
+There are no instructions in this file. All instructions are in `.agents/skills/**`.


### PR DESCRIPTION
## Proposed changes
This PR adds .agents/rules/INSTRUCTIONS.md
 to instruct Antigravity IDE to load and read the repository's custom skills in .agents/skills/ before responding to any requests. This ensures the agent adheres to project-specific guidelines.


## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Antigravity IDE specifically looks in .agents/rules/ for instructions, unlike other agents that may discover skills automatically. This addition bridges that gap.

closes #341
