### PR TITLE
fix: surface non-400 REST error response bodies

### DIFF
--- a/pkg/client/common/v1/rest.go
+++ b/pkg/client/common/v1/rest.go
@@ -86,13 +86,13 @@ func (c *RESTClient) HandleResponse(res *http.Response, keys []string, resBody i
 		detail, err := io.ReadAll(res.Body)
 		if err != nil {
 			klog.V(1).Infof("io.ReadAll failed. Err: %v\n", err)
-			return &interfaces.StatusError{Resp: res}
+			return nil, &interfaces.StatusError{Resp: res}
 		}
 
 		var e interfaces.DeepgramError
-		if err := json.Unmarshal(detail, &e); err == nil && e.ErrCode != "" {
+		if err := json.Unmarshal(detail, &e); err == nil && (e.ErrCode != "" || e.ErrMsg != "") {
 			klog.V(6).Infof("Parsed Deepgram Specific Error\n")
-			return &interfaces.StatusError{
+			return nil, &interfaces.StatusError{
 				Resp:          res,
 				DeepgramError: &e,
 			}
@@ -100,7 +100,7 @@ func (c *RESTClient) HandleResponse(res *http.Response, keys []string, resBody i
 
 		byDetails := bytes.TrimSpace(detail)
 		klog.V(1).Infof("Unable to parse Deepgram Error. Err: %s: %s\n", res.Status, byDetails)
-		return fmt.Errorf("%s: %s", res.Status, byDetails)
+		return nil, fmt.Errorf("%s: %s", res.Status, byDetails)
 	}
 }
 

--- a/pkg/client/common/v1/rest.go
+++ b/pkg/client/common/v1/rest.go
@@ -81,30 +81,26 @@ func (c *RESTClient) HandleResponse(res *http.Response, keys []string, resBody i
 	switch res.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 		return decodeResponseBody(res, keys, resBody)
-	case http.StatusBadRequest:
+	default:
 		klog.V(4).Infof("HTTP Error Code: %d\n", res.StatusCode)
 		detail, err := io.ReadAll(res.Body)
 		if err != nil {
-			klog.V(4).Infof("io.ReadAll failed. Err: %v\n", err)
-			return nil, &interfaces.StatusError{Resp: res}
+			klog.V(1).Infof("io.ReadAll failed. Err: %v\n", err)
+			return &interfaces.StatusError{Resp: res}
 		}
 
-		// attempt to parse out Deepgram error
 		var e interfaces.DeepgramError
-		if err := json.Unmarshal(detail, &e); err == nil {
+		if err := json.Unmarshal(detail, &e); err == nil && e.ErrCode != "" {
 			klog.V(6).Infof("Parsed Deepgram Specific Error\n")
-			return nil, &interfaces.StatusError{
+			return &interfaces.StatusError{
 				Resp:          res,
 				DeepgramError: &e,
 			}
 		}
 
-		// give standard generic error
 		byDetails := bytes.TrimSpace(detail)
 		klog.V(1).Infof("Unable to parse Deepgram Error. Err: %s: %s\n", res.Status, byDetails)
-		return nil, fmt.Errorf("%s: %s", res.Status, byDetails)
-	default:
-		return nil, &interfaces.StatusError{Resp: res}
+		return fmt.Errorf("%s: %s", res.Status, byDetails)
 	}
 }
 

--- a/pkg/client/common/v1/rest_test.go
+++ b/pkg/client/common/v1/rest_test.go
@@ -15,7 +15,7 @@ import (
 	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces/v1"
 )
 
-func TestHandleResponseReturnsDeepgramErrorForNonBadRequestStatus(t *testing.T) {
+func Test_HandleResponseReturnsDeepgramErrorForNonBadRequestStatus(t *testing.T) {
 	client := NewREST("test-api-key", &interfaces.ClientOptions{})
 	if client == nil {
 		t.Fatal("NewREST returned nil")
@@ -53,7 +53,7 @@ func TestHandleResponseReturnsDeepgramErrorForNonBadRequestStatus(t *testing.T) 
 	}
 }
 
-func TestHandleResponseReturnsPlainTextBodyForNonBadRequestStatus(t *testing.T) {
+func Test_HandleResponseReturnsPlainTextBodyForNonBadRequestStatus(t *testing.T) {
 	client := NewREST("test-api-key", &interfaces.ClientOptions{})
 	if client == nil {
 		t.Fatal("NewREST returned nil")

--- a/pkg/client/common/v1/rest_test.go
+++ b/pkg/client/common/v1/rest_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package commonv1
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces/v1"
+)
+
+func TestHandleResponseReturnsDeepgramErrorForNonBadRequestStatus(t *testing.T) {
+	client := NewREST("test-api-key", &interfaces.ClientOptions{})
+	if client == nil {
+		t.Fatal("NewREST returned nil")
+	}
+
+	res := newTestResponse(
+		http.StatusInternalServerError,
+		`{"err_code":"ENGINE_ERROR","err_msg":"engine failed","description":"model failed"}`,
+	)
+	defer res.Body.Close()
+
+	values, err := client.HandleResponse(res, nil, nil)
+	if values != nil {
+		t.Fatalf("values = %#v, want nil", values)
+	}
+	if err == nil {
+		t.Fatal("HandleResponse returned nil error")
+	}
+
+	var statusErr *interfaces.StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("HandleResponse returned %T, want *interfaces.StatusError", err)
+	}
+	if statusErr.Resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status code = %d, want %d", statusErr.Resp.StatusCode, http.StatusInternalServerError)
+	}
+	if statusErr.DeepgramError == nil {
+		t.Fatal("DeepgramError = nil")
+	}
+	if statusErr.DeepgramError.ErrCode != "ENGINE_ERROR" {
+		t.Fatalf("ErrCode = %q, want %q", statusErr.DeepgramError.ErrCode, "ENGINE_ERROR")
+	}
+	if statusErr.DeepgramError.ErrMsg != "engine failed" {
+		t.Fatalf("ErrMsg = %q, want %q", statusErr.DeepgramError.ErrMsg, "engine failed")
+	}
+}
+
+func TestHandleResponseReturnsPlainTextBodyForNonBadRequestStatus(t *testing.T) {
+	client := NewREST("test-api-key", &interfaces.ClientOptions{})
+	if client == nil {
+		t.Fatal("NewREST returned nil")
+	}
+
+	res := newTestResponse(
+		http.StatusServiceUnavailable,
+		"upstream unavailable",
+	)
+	defer res.Body.Close()
+
+	values, err := client.HandleResponse(res, nil, nil)
+	if values != nil {
+		t.Fatalf("values = %#v, want nil", values)
+	}
+	if err == nil {
+		t.Fatal("HandleResponse returned nil error")
+	}
+
+	got := err.Error()
+	if !strings.Contains(got, "503 Service Unavailable") {
+		t.Fatalf("error = %q, want status text", got)
+	}
+	if !strings.Contains(got, "upstream unavailable") {
+		t.Fatalf("error = %q, want response body", got)
+	}
+}
+
+func newTestResponse(statusCode int, body string) *http.Response {
+	req, _ := http.NewRequest(http.MethodGet, "https://api.deepgram.com/v1/listen", nil)
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}

--- a/pkg/client/rest/v1/rest.go
+++ b/pkg/client/rest/v1/rest.go
@@ -91,7 +91,6 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 	err := c.HTTPClient.Do(ctx, req, func(res *http.Response) error {
 		switch res.StatusCode {
 		case http.StatusOK, http.StatusCreated, http.StatusNoContent:
-			// Normal successful handling
 		default:
 			klog.V(4).Infof("HTTP Error Code: %d\n", res.StatusCode)
 			detail, err := io.ReadAll(res.Body)
@@ -101,7 +100,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 			}
 
 			var e interfaces.DeepgramError
-			if err := json.Unmarshal(detail, &e); err == nil && e.ErrCode != "" {
+			if err := json.Unmarshal(detail, &e); err == nil && (e.ErrCode != "" || e.ErrMsg != "") {
 				klog.V(6).Infof("Parsed Deepgram Specific Error\n")
 				return &interfaces.StatusError{
 					Resp:          res,

--- a/pkg/client/rest/v1/rest.go
+++ b/pkg/client/rest/v1/rest.go
@@ -90,20 +90,18 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 
 	err := c.HTTPClient.Do(ctx, req, func(res *http.Response) error {
 		switch res.StatusCode {
-		case http.StatusOK:
-		case http.StatusCreated:
-		case http.StatusNoContent:
-		case http.StatusBadRequest:
+		case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+			// Normal successful handling
+		default:
 			klog.V(4).Infof("HTTP Error Code: %d\n", res.StatusCode)
 			detail, err := io.ReadAll(res.Body)
 			if err != nil {
-				klog.V(4).Infof("io.ReadAll failed. Err: %v\n", err)
+				klog.V(1).Infof("io.ReadAll failed. Err: %v\n", err)
 				return &interfaces.StatusError{Resp: res}
 			}
 
-			// attempt to parse out Deepgram error
 			var e interfaces.DeepgramError
-			if err := json.Unmarshal(detail, &e); err == nil {
+			if err := json.Unmarshal(detail, &e); err == nil && e.ErrCode != "" {
 				klog.V(6).Infof("Parsed Deepgram Specific Error\n")
 				return &interfaces.StatusError{
 					Resp:          res,
@@ -111,12 +109,9 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 				}
 			}
 
-			// give standard generic error
 			byDetails := bytes.TrimSpace(detail)
 			klog.V(1).Infof("Unable to parse Deepgram Error. Err: %s: %s\n", res.Status, byDetails)
 			return fmt.Errorf("%s: %s", res.Status, byDetails)
-		default:
-			return &interfaces.StatusError{Resp: res}
 		}
 
 		if resBody == nil {

--- a/pkg/client/rest/v1/rest_test.go
+++ b/pkg/client/rest/v1/rest_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package restv1
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces/v1"
+)
+
+func TestDoReturnsDeepgramErrorForNonBadRequestStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"err_code":"ENGINE_ERROR","err_msg":"engine failed","description":"model failed"}`))
+	}))
+	defer server.Close()
+
+	client := New(&interfaces.ClientOptions{APIKey: "test-api-key", Host: server.URL})
+	if client == nil {
+		t.Fatal("New returned nil")
+	}
+
+	req, err := client.SetupRequest(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("SetupRequest returned error: %v", err)
+	}
+
+	err = client.Do(context.Background(), req, nil)
+	if err == nil {
+		t.Fatal("Do returned nil error")
+	}
+
+	var statusErr *interfaces.StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("Do returned %T, want *interfaces.StatusError", err)
+	}
+	if statusErr.Resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status code = %d, want %d", statusErr.Resp.StatusCode, http.StatusInternalServerError)
+	}
+	if statusErr.DeepgramError == nil {
+		t.Fatal("DeepgramError = nil")
+	}
+	if statusErr.DeepgramError.ErrCode != "ENGINE_ERROR" {
+		t.Fatalf("ErrCode = %q, want %q", statusErr.DeepgramError.ErrCode, "ENGINE_ERROR")
+	}
+	if statusErr.DeepgramError.ErrMsg != "engine failed" {
+		t.Fatalf("ErrMsg = %q, want %q", statusErr.DeepgramError.ErrMsg, "engine failed")
+	}
+}
+
+func TestDoReturnsPlainTextBodyForNonBadRequestStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("upstream unavailable"))
+	}))
+	defer server.Close()
+
+	client := New(&interfaces.ClientOptions{APIKey: "test-api-key", Host: server.URL})
+	if client == nil {
+		t.Fatal("New returned nil")
+	}
+
+	req, err := client.SetupRequest(context.Background(), http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatalf("SetupRequest returned error: %v", err)
+	}
+
+	err = client.Do(context.Background(), req, nil)
+	if err == nil {
+		t.Fatal("Do returned nil error")
+	}
+
+	got := err.Error()
+	if !strings.Contains(got, "503 Service Unavailable") {
+		t.Fatalf("error = %q, want status text", got)
+	}
+	if !strings.Contains(got, "upstream unavailable") {
+		t.Fatalf("error = %q, want response body", got)
+	}
+}

--- a/pkg/client/rest/v1/rest_test.go
+++ b/pkg/client/rest/v1/rest_test.go
@@ -15,7 +15,7 @@ import (
 	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces/v1"
 )
 
-func TestDoReturnsDeepgramErrorForNonBadRequestStatus(t *testing.T) {
+func Test_DoReturnsDeepgramErrorForNonBadRequestStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -56,7 +56,7 @@ func TestDoReturnsDeepgramErrorForNonBadRequestStatus(t *testing.T) {
 	}
 }
 
-func TestDoReturnsPlainTextBodyForNonBadRequestStatus(t *testing.T) {
+func Test_DoReturnsPlainTextBodyForNonBadRequestStatus(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte("upstream unavailable"))


### PR DESCRIPTION
## Proposed changes
  <!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a
  bug or resolves a feature request, be sure to link to that issue.
  -->

  Fixes #332

  Hit this issue on a self-hosted setup where non-400 REST errors were hard to debug because the response body was dropped in the`default:` branch. This updates the REST error handling so response bodies are parsed or surfaced for all non-success statuses.

  ## What I changed

  - Parse error response bodies for all non-success REST statuses, not just HTTP 400.
  - Preserve Deepgram JSON errors as `StatusError.DeepgramError`.
  - Surface non-JSON/plain-text error bodies in the returned error message.
  - Apply the behavior in both REST client paths:
    - `pkg/client/rest/v1/rest.go`
    - `pkg/client/common/v1/rest.go`

  ## Tests

  Added coverage for:
  - 500 responses with Deepgram JSON error bodies
  - 503 responses with plain-text bodies
  - Tuple return behavior in `common/v1`

  Verified with:

  ```bash
  go test ./pkg/client/...
  PATH=/private/tmp/deepgram-local-tools/actionlint-1.6.27:/opt/homebrew/Cellar/diffutils/3.12/bin:/Users/shria/sdk/go1.19.13/bin:$PATH
  make check
```

  ## Types of changes

  What types of changes does your code introduce to the community Go SDK?
  Put an x in the boxes that apply

  - [x] Bugfix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentation update or tests (if none of the other choices apply)

  ## Checklist

  Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate
  to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

  - [x] I have read the ../CONTRIBUTING.md doc
  - [x] I have lint'ed all of my code using repo standards
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
N/A :)