### PR TITLE
fix(speak): send Clear instead of invalid Reset

### DIFF
--- a/.agents/skills/deepgram-go-text-to-speech/SKILL.md
+++ b/.agents/skills/deepgram-go-text-to-speech/SKILL.md
@@ -133,7 +133,8 @@ func run() error {
 - REST methods
 	- via `pkg/api/speak/v1/rest`: `api.New(client).ToStream`, `ToFile`, `ToSave`
 - WS methods
-	- `SpeakWithText`, `Speak`, `Flush`, `Reset`
+	- `SpeakWithText`, `Speak`, `Flush`, `Clear`
+	- `Reset` is deprecated; use `Clear` instead
 - constructors
 	- `speak.NewRESTWithDefaults()` / `speak.NewREST(...)`
 	- `speak.NewWSUsingCallback...`

--- a/examples/text-to-speech/websocket/interactive_callback/main.go
+++ b/examples/text-to-speech/websocket/interactive_callback/main.go
@@ -133,18 +133,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Simulate user input to reset the buffer, flush, send new text, or just exit
+	// Simulate user input to clear the buffer, flush, send new text, or just exit
 	time.Sleep(2 * time.Second)
-	fmt.Printf("\n\nPress 'r' and ENTER to reset the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
+	fmt.Printf("\n\nPress 'c' and ENTER to clear the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
 	input := bufio.NewScanner(os.Stdin)
 	for input.Scan() {
 		switch input.Text() {
-		case "r":
-			err = dgClient.Reset()
+		case "c":
+			err = dgClient.Clear()
 			if err != nil {
-				fmt.Printf("Error resetting buffer: %v\n", err)
+				fmt.Printf("Error clearing buffer: %v\n", err)
 			} else {
-				fmt.Println("Buffer reset successfully.")
+				fmt.Println("Buffer cleared successfully.")
 			}
 		case "f":
 			// delete file if exists

--- a/examples/text-to-speech/websocket/interactive_callback/main.go
+++ b/examples/text-to-speech/websocket/interactive_callback/main.go
@@ -58,13 +58,13 @@ func (c MyCallback) Binary(byMsg []byte) error {
 
 func (c MyCallback) Flush(fl *msginterfaces.FlushedResponse) error {
 	fmt.Printf("\n[Flushed] Received\n")
-	fmt.Printf("\n\nPress 'r' and ENTER to reset the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
+	fmt.Printf("\n\nPress 'c' and ENTER to clear the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
 	return nil
 }
 
 func (c MyCallback) Clear(fl *msginterfaces.ClearedResponse) error {
 	fmt.Printf("\n[Cleared] Received\n")
-	fmt.Printf("\n\nPress 'r' and ENTER to reset the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
+	fmt.Printf("\n\nPress 'c' and ENTER to clear the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
 	return nil
 }
 
@@ -196,7 +196,7 @@ func main() {
 			} else {
 				fmt.Println("Text sent successfully.")
 			}
-			fmt.Printf("\n\nPress 'r' and ENTER to reset the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
+			fmt.Printf("\n\nPress 'c' and ENTER to clear the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
 		}
 	}
 

--- a/examples/text-to-speech/websocket/interactive_channel/main.go
+++ b/examples/text-to-speech/websocket/interactive_channel/main.go
@@ -328,7 +328,7 @@ func main() {
 			} else {
 				fmt.Println("Text sent successfully.")
 			}
-			fmt.Printf("\n\nPress 'r' and ENTER to reset the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
+			fmt.Printf("\n\nPress 'c' and ENTER to clear the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
 		}
 	}
 

--- a/examples/text-to-speech/websocket/interactive_channel/main.go
+++ b/examples/text-to-speech/websocket/interactive_channel/main.go
@@ -265,18 +265,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Simulate user input to reset the buffer, flush, send new text, or just exit
+	// Simulate user input to clear the buffer, flush, send new text, or just exit
 	time.Sleep(2 * time.Second)
-	fmt.Printf("\n\nPress 'r' and ENTER to reset the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
+	fmt.Printf("\n\nPress 'c' and ENTER to clear the buffer, 'f' and ENTER to flush, enter new text to send it, or just ENTER to exit...\n\n> ")
 	input := bufio.NewScanner(os.Stdin)
 	for input.Scan() {
 		switch input.Text() {
-		case "r":
-			err = dgClient.Reset()
+		case "c":
+			err = dgClient.Clear()
 			if err != nil {
-				fmt.Printf("Error resetting buffer: %v\n", err)
+				fmt.Printf("Error clearing buffer: %v\n", err)
 			} else {
-				fmt.Println("Buffer reset successfully.")
+				fmt.Println("Buffer cleared successfully.")
 			}
 		case "f":
 			// delete file if exists

--- a/pkg/client/speak/v1/websocket/client_callback.go
+++ b/pkg/client/speak/v1/websocket/client_callback.go
@@ -187,6 +187,7 @@ func (c *WSCallback) Clear() error {
 }
 
 // Reset is deprecated because Speak v1 accepts Clear, not Reset.
+//
 // Deprecated: Use Clear instead.
 func (c *WSCallback) Reset() error {
 	return c.Clear()

--- a/pkg/client/speak/v1/websocket/client_callback.go
+++ b/pkg/client/speak/v1/websocket/client_callback.go
@@ -169,21 +169,27 @@ func (c *WSCallback) Flush() error {
 	return err
 }
 
-// Reset will instruct the server to reset the current buffer
-func (c *WSCallback) Reset() error {
-	klog.V(6).Infof("speak.Reset() ENTER\n")
+// Clear instructs the server to clear the current text buffer.
+func (c *WSCallback) Clear() error {
+	klog.V(6).Infof("speak.Clear() ENTER\n")
 
-	err := c.WriteJSON(controlMessage{Type: MessageTypeReset})
+	err := c.WriteJSON(controlMessage{Type: MessageTypeClear})
 	if err != nil {
-		klog.V(1).Infof("Reset failed. Err: %v\n", err)
-		klog.V(6).Infof("speak.Reset() LEAVE\n")
+		klog.V(1).Infof("Clear failed. Err: %v\n", err)
+		klog.V(6).Infof("speak.Clear() LEAVE\n")
 
 		return err
 	}
 
-	klog.V(4).Infof("Reset Succeeded\n")
-	klog.V(6).Infof("speak.Reset() LEAVE\n")
-	return nil
+	klog.V(4).Infof("Clear Succeeded\n")
+	klog.V(6).Infof("speak.Clear() LEAVE\n")
+	return err
+}
+
+// Reset is deprecated because Speak v1 accepts Clear, not Reset.
+// Deprecated: Use Clear instead.
+func (c *WSCallback) Reset() error {
+	return c.Clear()
 }
 
 // GetCloseMsg sends an application level message to Deepgram

--- a/pkg/client/speak/v1/websocket/client_channel.go
+++ b/pkg/client/speak/v1/websocket/client_channel.go
@@ -168,21 +168,27 @@ func (c *WSChannel) Flush() error {
 	return err
 }
 
-// Reset will instruct the server to reset the current buffer
-func (c *WSChannel) Reset() error {
-	klog.V(6).Infof("speak.Reset() ENTER\n")
+// Clear instructs the server to clear the current text buffer.
+func (c *WSChannel) Clear() error {
+	klog.V(6).Infof("speak.Clear() ENTER\n")
 
-	err := c.WriteJSON(controlMessage{Type: MessageTypeReset})
+	err := c.WriteJSON(controlMessage{Type: MessageTypeClear})
 	if err != nil {
-		klog.V(1).Infof("Reset failed. Err: %v\n", err)
-		klog.V(6).Infof("speak.Reset() LEAVE\n")
+		klog.V(1).Infof("Clear failed. Err: %v\n", err)
+		klog.V(6).Infof("speak.Clear() LEAVE\n")
 
 		return err
 	}
 
-	klog.V(4).Infof("Reset Succeeded\n")
-	klog.V(6).Infof("speak.Reset() LEAVE\n")
-	return nil
+	klog.V(4).Infof("Clear Succeeded\n")
+	klog.V(6).Infof("speak.Clear() LEAVE\n")
+	return err
+}
+
+// Reset is deprecated because Speak v1 accepts Clear, not Reset.
+// Deprecated: Use Clear instead.
+func (c *WSChannel) Reset() error {
+	return c.Clear()
 }
 
 // GetCloseMsg sends an application level message to Deepgram

--- a/pkg/client/speak/v1/websocket/client_channel.go
+++ b/pkg/client/speak/v1/websocket/client_channel.go
@@ -186,6 +186,7 @@ func (c *WSChannel) Clear() error {
 }
 
 // Reset is deprecated because Speak v1 accepts Clear, not Reset.
+//
 // Deprecated: Use Clear instead.
 func (c *WSChannel) Reset() error {
 	return c.Clear()

--- a/pkg/client/speak/v1/websocket/constants.go
+++ b/pkg/client/speak/v1/websocket/constants.go
@@ -21,14 +21,18 @@ const (
 )
 
 const (
-	// MessageTypeFlush flushes the audio from the server
+	// MessageTypeSpeak adds text to the server's synthesis buffer.
 	MessageTypeSpeak string = "Speak"
 
-	// MessageTypeFlush flushes the audio from the server
+	// MessageTypeFlush flushes the server's synthesis buffer.
 	MessageTypeFlush string = "Flush"
 
-	// MessageTypeReset resets the text buffer
-	MessageTypeReset string = "Reset"
+	// MessageTypeClear clears the server's synthesis buffer.
+	MessageTypeClear string = "Clear"
+
+	// MessageTypeReset is kept for compatibility but emits the supported Clear message.
+	// Deprecated: Use MessageTypeClear instead.
+	MessageTypeReset = MessageTypeClear
 
 	// MessageTypeClose closes the stream
 	MessageTypeClose string = "Close"

--- a/pkg/client/speak/v1/websocket/constants.go
+++ b/pkg/client/speak/v1/websocket/constants.go
@@ -31,6 +31,7 @@ const (
 	MessageTypeClear string = "Clear"
 
 	// MessageTypeReset is kept for compatibility but emits the supported Clear message.
+	//
 	// Deprecated: Use MessageTypeClear instead.
 	MessageTypeReset = MessageTypeClear
 

--- a/pkg/client/speak/v1/websocket/control_message_test.go
+++ b/pkg/client/speak/v1/websocket/control_message_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/dvonthenen/websocket"
 )
 
-func TestClearControlMessage(t *testing.T) {
+func Test_ClearControlMessage(t *testing.T) {
 	if MessageTypeReset != MessageTypeClear {
 		t.Fatalf("MessageTypeReset = %q, want %q", MessageTypeReset, MessageTypeClear)
 	}

--- a/pkg/client/speak/v1/websocket/control_message_test.go
+++ b/pkg/client/speak/v1/websocket/control_message_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package websocketv1
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestClearControlMessage(t *testing.T) {
+	if MessageTypeReset != MessageTypeClear {
+		t.Fatalf("MessageTypeReset = %q, want %q", MessageTypeReset, MessageTypeClear)
+	}
+
+	data, err := json.Marshal(controlMessage{Type: MessageTypeClear})
+	if err != nil {
+		t.Fatalf("marshal clear control message: %v", err)
+	}
+
+	if got, want := string(data), `{"type":"Clear"}`; got != want {
+		t.Errorf("clear payload = %s, want %s", got, want)
+	}
+}

--- a/pkg/client/speak/v1/websocket/control_message_test.go
+++ b/pkg/client/speak/v1/websocket/control_message_test.go
@@ -5,8 +5,15 @@
 package websocketv1
 
 import (
-	"encoding/json"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	interfaces "github.com/deepgram/deepgram-go-sdk/v3/pkg/client/interfaces/v1"
+	"github.com/dvonthenen/websocket"
 )
 
 func TestClearControlMessage(t *testing.T) {
@@ -14,12 +21,102 @@ func TestClearControlMessage(t *testing.T) {
 		t.Fatalf("MessageTypeReset = %q, want %q", MessageTypeReset, MessageTypeClear)
 	}
 
-	data, err := json.Marshal(controlMessage{Type: MessageTypeClear})
-	if err != nil {
-		t.Fatalf("marshal clear control message: %v", err)
-	}
+	t.Run("callback Clear", func(t *testing.T) {
+		testCallbackControlMessage(t, func(client *WSCallback) error { return client.Clear() })
+	})
+	t.Run("callback Reset", func(t *testing.T) {
+		testCallbackControlMessage(t, func(client *WSCallback) error { return client.Reset() })
+	})
+	t.Run("channel Clear", func(t *testing.T) {
+		testChannelControlMessage(t, func(client *WSChannel) error { return client.Clear() })
+	})
+	t.Run("channel Reset", func(t *testing.T) {
+		testChannelControlMessage(t, func(client *WSChannel) error { return client.Reset() })
+	})
+}
 
-	if got, want := string(data), `{"type":"Clear"}`; got != want {
-		t.Errorf("clear payload = %s, want %s", got, want)
+func testCallbackControlMessage(t *testing.T, call func(*WSCallback) error) {
+	t.Helper()
+	host, received := newControlMessageServer(t)
+	client, err := NewUsingCallback(context.Background(), "test-api-key", testClientOptions(host), testSpeakOptions(), nil)
+	if err != nil {
+		t.Fatalf("create callback client: %v", err)
+	}
+	t.Cleanup(client.Stop)
+	if !client.Connect() {
+		t.Fatal("connect callback client")
+	}
+	if err := call(client); err != nil {
+		t.Fatalf("send control message: %v", err)
+	}
+	expectClearControlMessage(t, received)
+}
+
+func testChannelControlMessage(t *testing.T, call func(*WSChannel) error) {
+	t.Helper()
+	host, received := newControlMessageServer(t)
+	client, err := NewUsingChan(context.Background(), "test-api-key", testClientOptions(host), testSpeakOptions(), nil)
+	if err != nil {
+		t.Fatalf("create channel client: %v", err)
+	}
+	t.Cleanup(client.Stop)
+	if !client.Connect() {
+		t.Fatal("connect channel client")
+	}
+	if err := call(client); err != nil {
+		t.Fatalf("send control message: %v", err)
+	}
+	expectClearControlMessage(t, received)
+}
+
+func newControlMessageServer(t *testing.T) (string, <-chan string) {
+	t.Helper()
+	received := make(chan string, 2)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		for {
+			messageType, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if messageType == websocket.TextMessage {
+				received <- string(data)
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return "ws" + strings.TrimPrefix(server.URL, "http"), received
+}
+
+func testClientOptions(host string) *interfaces.ClientOptions {
+	return &interfaces.ClientOptions{
+		Host: host,
+		WSHeaderProcessor: func(headers http.Header) {
+			headers.Del("Host")
+		},
+	}
+}
+
+func testSpeakOptions() *interfaces.WSSpeakOptions {
+	return &interfaces.WSSpeakOptions{Model: "aura-asteria-en"}
+}
+
+func expectClearControlMessage(t *testing.T, received <-chan string) {
+	t.Helper()
+	select {
+	case got := <-received:
+		if want := `{"type":"Clear"}`; got != want {
+			t.Errorf("control message = %s, want %s", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for control message")
 	}
 }


### PR DESCRIPTION
## Summary
- add `Clear()` to Speak v1 callback and channel clients
- make deprecated `Reset()` delegate to `Clear()` so existing callers send the supported control frame
- retain `MessageTypeReset` as a deprecated `Clear` alias for source compatibility
- add an exact wire-payload regression test

## Verification
- `go test ./pkg/client/speak/v1/websocket ./tests/unit_test`

Fixes #347.