### PR TITLE
docs: add CLAUDE.md contributor guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,9 @@ For a new pre-recorded transcription query parameter:
 3. Add a focused unit test proving the query parameter or response field
    reaches the wire contract.
 4. Update the closest runnable example under `examples/speech-to-text/rest`.
-5. Run the focused package test, `go test ./tests/unit_test/...`, and the CI
+5. Run a focused test, such as
+   `go test ./tests/unit_test -run Test_PrerecordedDiarizeModel`, then run the
+   full deterministic suite with `go test ./tests/unit_test/...` and the CI
    command `go test -v -run Test_ ./...`.
 
 ## Pull Requests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# Deepgram Go SDK
+
+## Repository Purpose
+
+This is the official Go SDK for Deepgram APIs. The module path is
+`github.com/deepgram/deepgram-go-sdk/v3`, and the supported Go version is 1.19
+or newer.
+
+Read `README.md` and `.github/CONTRIBUTING.md` before changing public behavior.
+Do not hardcode API keys or access tokens; examples and tests should use the
+SDK's environment-backed client defaults.
+
+## Layout
+
+- `pkg/api/<product>/<version>`: public API facades, request/response models,
+  routers, and callbacks.
+- `pkg/client/<product>/<version>`: REST and WebSocket transport clients.
+- `pkg/client/interfaces`: shared public option types. Versioned types live in
+  `v1` and `v2` and are re-exported here when appropriate.
+- `pkg/client/common`: shared REST and WebSocket behavior.
+- `pkg/api/version`: endpoint URL and query-parameter construction.
+- `examples`: runnable, product-specific usage.
+- `tests/unit_test`: deterministic unit tests. `tests/daily_test` uses live
+  service responses and may refresh response fixtures.
+
+Use `listen` for Speech-to-Text, `speak` for Text-to-Speech, `analyze` for
+text intelligence, `agent` for Voice Agent, and `manage` or `auth` for
+management and token operations. Legacy `live`, `prerecorded`, and `rest`
+packages are deprecated; do not use them for new code.
+
+## Implementation Conventions
+
+- Keep public changes additive whenever possible. Preserve deprecated aliases
+  when replacing a public method or constant.
+- Put version-specific protocol types in the matching `v1` or `v2` package.
+  Do not reuse a model across REST and WebSocket protocols unless their wire
+  formats are identical.
+- Use `context.Context` for request and connection lifetime. WebSocket clients
+  expose separate callback and channel variants; preserve both when changing
+  their behavior.
+- Match JSON tags and optionality to the wire contract. Test fields whose zero
+  value is meaningful when the model is re-marshaled.
+- Return errors to callers. Do not log credentials, and do not change global
+  logging or process flag behavior from ordinary client code.
+- Keep examples idiomatic and runnable. Update affected examples and public
+  documentation with every API change.
+
+## Validation
+
+Run the narrowest relevant check first:
+
+```bash
+go test ./tests/unit_test
+go test -v -run Test_ ./...
+go vet ./...
+go mod verify
+```
+
+CI uses Go 1.19 and runs `go test -v -run Test_ ./...`. Name unit tests with
+the `Test_` prefix so CI executes them. Run `make lint` with Go 1.19 for Go
+changes. Run `make mdlint` for Markdown changes.
+
+Use `go test ./...` deliberately: it includes `tests/daily_test`, which makes
+live service calls and can update tracked response fixtures.
+
+## Pull Requests
+
+- Keep diffs focused on one issue or behavior change.
+- Add regression coverage for bug fixes, including exact REST or WebSocket
+  wire behavior when the bug is a serialization or protocol mismatch.
+- State the commands run and link the related issue. Use `Fixes #<issue>` only
+  when the PR fully resolves it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ SDK's environment-backed client defaults.
   routers, and callbacks.
 - `pkg/client/<product>/<version>`: REST and WebSocket transport clients.
 - `pkg/client/interfaces`: shared public option types. Versioned types live in
-  `v1` and `v2` and are re-exported here when appropriate.
+  `v1` (Nova REST and WebSocket, Speak, Agent, Analyze) and `v2` (the Flux
+  conversational speech-to-text WebSocket client in `pkg/client/listen/v2`,
+  options in `types-flux.go`) and are re-exported here when appropriate.
 - `pkg/client/common`: shared REST and WebSocket behavior.
 - `pkg/api/version`: endpoint URL and query-parameter construction.
 - `examples`: runnable, product-specific usage.
@@ -40,8 +42,11 @@ packages are deprecated; do not use them for new code.
   both when changing their behavior. Voice Agent is channel-based.
 - Match JSON tags and optionality to the wire contract. Test fields whose zero
   value is meaningful when the model is re-marshaled.
-- Return errors to callers. Do not log credentials, and do not change global
-  logging or process flag behavior from ordinary client code.
+- Return errors to callers. Existing `pkg/api/manage/v1` methods (all but
+  `invitations.go`) return `&resp, nil` after a failed request; that is a known
+  defect, so do not copy it into new code and do not change it without a
+  tracked issue. Do not log credentials, and do not change global logging or
+  process flag behavior from ordinary client code.
 - Keep examples idiomatic and runnable. Update affected examples and public
   documentation with every API change.
 
@@ -62,7 +67,8 @@ go mod verify
 
 CI uses Go 1.19 and runs `go test -v -run Test_ ./...`. Name unit tests with
 the `Test_` prefix so CI executes them. Run `make lint` with Go 1.19 for Go
-changes. Run `make mdlint` for Markdown changes.
+changes and read its output: it currently exits 0 even when golangci-lint
+reports issues. Run `make mdlint` for Markdown changes.
 
 Use `go test ./...` deliberately: it includes `tests/daily_test`, which makes
 live service calls and can update tracked response fixtures.
@@ -76,7 +82,10 @@ For a new pre-recorded transcription query parameter:
 2. Add or update the corresponding typed response model under
    `pkg/api/listen/v1/rest/interfaces` when the API returns new data.
 3. Add a focused unit test proving the query parameter or response field
-   reaches the wire contract.
+   reaches the wire contract. Files in `tests/unit_test` use
+   `package deepgram_test` and must sort alphabetically after `mocks.go`; a
+   name that sorts before it fails the build with
+   `found packages deepgram ... and deepgram_test`.
 4. Update the closest runnable example under `examples/speech-to-text/rest`.
 5. Run a focused test, such as
    `go test ./tests/unit_test -run Test_PrerecordedDiarizeModel`, then run the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,9 @@ packages are deprecated; do not use them for new code.
 - Put version-specific protocol types in the matching `v1` or `v2` package.
   Do not reuse a model across REST and WebSocket protocols unless their wire
   formats are identical.
-- Use `context.Context` for request and connection lifetime. WebSocket clients
-  expose separate callback and channel variants; preserve both when changing
-  their behavior.
+- Use `context.Context` for request and connection lifetime. Listen and Speak
+  WebSocket clients expose separate callback and channel variants; preserve
+  both when changing their behavior. Voice Agent is channel-based.
 - Match JSON tags and optionality to the wire contract. Test fields whose zero
   value is meaningful when the model is re-marshaled.
 - Return errors to callers. Do not log credentials, and do not change global
@@ -47,10 +47,14 @@ packages are deprecated; do not use them for new code.
 
 ## Validation
 
+Follow `.github/CODE_CONTRIBUTIONS_GUIDE.md` when preparing a development
+environment. Run `make ensure-deps` after cloning to install project tools,
+including the PortAudio dependency required to compile audio packages.
+
 Run the narrowest relevant check first:
 
 ```bash
-go test ./tests/unit_test
+go test ./tests/unit_test/...
 go test -v -run Test_ ./...
 go vet ./...
 go mod verify
@@ -62,6 +66,20 @@ changes. Run `make mdlint` for Markdown changes.
 
 Use `go test ./...` deliberately: it includes `tests/daily_test`, which makes
 live service calls and can update tracked response fixtures.
+
+## Example: Add A Listen v1 Option
+
+For a new pre-recorded transcription query parameter:
+
+1. Add the typed field and its `schema` tag to
+   `pkg/client/interfaces/v1/types-prerecorded.go`.
+2. Add or update the corresponding typed response model under
+   `pkg/api/listen/v1/rest/interfaces` when the API returns new data.
+3. Add a focused unit test proving the query parameter or response field
+   reaches the wire contract.
+4. Update the closest runnable example under `examples/speech-to-text/rest`.
+5. Run the focused package test, `go test ./tests/unit_test/...`, and the CI
+   command `go test -v -run Test_ ./...`.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary
- add a root `CLAUDE.md` with the Go SDK architecture and package layout
- document implementation conventions for REST, WebSocket, versioned types, errors, and public compatibility
- document the Go 1.19 CI test convention and focused validation commands

## Verification
- `make mdlint`

Fixes #352.